### PR TITLE
V1 Pinecone Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
 
     - name: Run pytest
       run: |
-        poetry run pytest vectordb_orm
+        poetry run pytest -s vectordb_orm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,8 @@ jobs:
         poetry install
 
     - name: Run pytest
+      env:
+        PINECONE_API_KEY: ${{ secrets.PINECONE_API_KEY }}
+        PINECONE_ENVIRONMENT: ${{ secrets.PINECONE_ENVIRONMENT }}
       run: |
         poetry run pytest -s vectordb_orm

--- a/poetry.lock
+++ b/poetry.lock
@@ -78,6 +78,20 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "isort"
+version = "5.12.0"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.8.0"
+
+[package.extras]
+colors = ["colorama (>=0.4.3)"]
+pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
+plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
 name = "loguru"
 version = "0.7.0"
 description = "Python logging made (stupidly) simple"
@@ -371,7 +385,7 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "5f1918e2ecdaf84015e723b7914acc95b884c2623c72c3b58ba5c375f9f5ca03"
+content-hash = "fb360da7cdf923249ea6c8602f9c2e8268a2362d2a97aa8964985d167a16aa2b"
 
 [metadata.files]
 certifi = [
@@ -521,6 +535,10 @@ idna = [
 iniconfig = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+isort = [
+    {file = "isort-5.12.0-py3-none-any.whl", hash = "sha256:f84c2818376e66cf843d497486ea8fed8700b340f308f076c6fb1229dff318b6"},
+    {file = "isort-5.12.0.tar.gz", hash = "sha256:8bef7dde241278824a6d83f44a544709b065191b95b6e50894bdc722fcba0504"},
 ]
 loguru = [
     {file = "loguru-0.7.0-py3-none-any.whl", hash = "sha256:b93aa30099fa6860d4727f1b81f8718e965bb96253fa190fab2077aaad6d15d3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -243,6 +243,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "1.0.0"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "pytz"
 version = "2023.3"
 description = "World timezone definitions, modern and historical"
@@ -360,7 +371,7 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "ff9d9ce70dbd06638f8efbb4513488b332ea7a5ca2095369bac5c3fb975f3a14"
+content-hash = "5f1918e2ecdaf84015e723b7914acc95b884c2623c72c3b58ba5c375f9f5ca03"
 
 [metadata.files]
 certifi = [
@@ -647,6 +658,10 @@ pytest = [
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-dotenv = [
+    {file = "python-dotenv-1.0.0.tar.gz", hash = "sha256:a8df96034aae6d2d50a4ebe8216326c61c3eb64836776504fcca410e5937a3ba"},
+    {file = "python_dotenv-1.0.0-py3-none-any.whl", hash = "sha256:f5971a9226b701070a4bf2c38c89e5a3f0d64de8debda981d1db98583009122a"},
 ]
 pytz = [
     {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,10 +1,43 @@
 [[package]]
+name = "certifi"
+version = "2022.12.7"
+description = "Python package for providing Mozilla's CA Bundle."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "charset-normalizer"
+version = "3.1.0"
+description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
+category = "main"
+optional = false
+python-versions = ">=3.7.0"
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
-category = "dev"
+category = "main"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+
+[[package]]
+name = "dnspython"
+version = "2.3.0"
+description = "DNS toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.extras]
+curio = ["curio (>=1.2,<2.0)", "sniffio (>=1.1,<2.0)"]
+dnssec = ["cryptography (>=2.6,<40.0)"]
+doh = ["h2 (>=4.1.0)", "httpx (>=0.21.1)", "requests (>=2.23.0,<3.0.0)", "requests-toolbelt (>=0.9.1,<0.11.0)"]
+doq = ["aioquic (>=0.9.20)"]
+idna = ["idna (>=2.1,<4.0)"]
+trio = ["trio (>=0.14,<0.23)"]
+wmi = ["wmi (>=1.5.1,<2.0.0)"]
 
 [[package]]
 name = "exceptiongroup"
@@ -29,12 +62,35 @@ python-versions = ">=3.7"
 protobuf = ["grpcio-tools (>=1.53.0)"]
 
 [[package]]
+name = "idna"
+version = "3.4"
+description = "Internationalized Domain Names in Applications (IDNA)"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "loguru"
+version = "0.7.0"
+description = "Python logging made (stupidly) simple"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (==5.3.0)", "colorama (==0.4.5)", "colorama (==0.4.6)", "freezegun (==1.1.0)", "freezegun (==1.2.2)", "mypy (==v0.910)", "mypy (==v0.971)", "mypy (==v0.990)", "pre-commit (==3.2.1)", "pytest (==6.1.2)", "pytest (==7.2.1)", "pytest-cov (==2.12.1)", "pytest-cov (==4.0.0)", "pytest-mypy-plugins (==1.10.1)", "pytest-mypy-plugins (==1.9.3)", "sphinx-autobuild (==2021.3.14)", "sphinx-rtd-theme (==1.2.0)", "tox (==3.27.1)", "tox (==4.4.6)"]
 
 [[package]]
 name = "mmh3"
@@ -99,6 +155,28 @@ spss = ["pyreadstat (>=1.1.2)"]
 sql-other = ["SQLAlchemy (>=1.4.16)"]
 test = ["hypothesis (>=6.34.2)", "pytest (>=7.0.0)", "pytest-asyncio (>=0.17.0)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.6.3)"]
+
+[[package]]
+name = "pinecone-client"
+version = "2.2.1"
+description = "Pinecone client and SDK"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+loguru = ">=0.5.0"
+numpy = "*"
+python-dateutil = ">=2.5.3"
+pyyaml = ">=5.4"
+requests = ">=2.19.0"
+tqdm = ">=4.64.1"
+typing-extensions = ">=3.7.4"
+urllib3 = ">=1.21.1"
+
+[package.extras]
+grpc = ["googleapis-common-protos (>=1.53.0)", "grpc-gateway-protoc-gen-openapiv2 (==0.1.0)", "grpcio (>=1.44.0)", "lz4 (>=3.1.3)", "protobuf (==3.19.3)"]
 
 [[package]]
 name = "pluggy"
@@ -173,6 +251,32 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "PyYAML"
+version = "6.0"
+description = "YAML parser and emitter for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "requests"
+version = "2.28.2"
+description = "Python HTTP for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+charset-normalizer = ">=2,<4"
+idna = ">=2.5,<4"
+urllib3 = ">=1.21.1,<1.27"
+
+[package.extras]
+socks = ["PySocks (>=1.5.6,!=1.5.7)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -185,6 +289,31 @@ name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
 category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "tqdm"
+version = "4.65.0"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
+name = "typing-extensions"
+version = "4.5.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -204,15 +333,124 @@ category = "main"
 optional = false
 python-versions = ">=3.7"
 
+[[package]]
+name = "urllib3"
+version = "1.26.15"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "win32-setctime"
+version = "1.1.0"
+description = "A small Python utility to set file creation time on Windows"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "bd8365de5d0f488e911cc85ab849840708c885cea09c0e80157f37527bd414a6"
+content-hash = "ff9d9ce70dbd06638f8efbb4513488b332ea7a5ca2095369bac5c3fb975f3a14"
 
 [metadata.files]
+certifi = [
+    {file = "certifi-2022.12.7-py3-none-any.whl", hash = "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"},
+    {file = "certifi-2022.12.7.tar.gz", hash = "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-3.1.0.tar.gz", hash = "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-win32.whl", hash = "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448"},
+    {file = "charset_normalizer-3.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-win32.whl", hash = "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909"},
+    {file = "charset_normalizer-3.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-win32.whl", hash = "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974"},
+    {file = "charset_normalizer-3.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-win32.whl", hash = "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0"},
+    {file = "charset_normalizer-3.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-win32.whl", hash = "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1"},
+    {file = "charset_normalizer-3.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b"},
+    {file = "charset_normalizer-3.1.0-py3-none-any.whl", hash = "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d"},
+]
 colorama = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+dnspython = [
+    {file = "dnspython-2.3.0-py3-none-any.whl", hash = "sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46"},
+    {file = "dnspython-2.3.0.tar.gz", hash = "sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9"},
 ]
 exceptiongroup = [
     {file = "exceptiongroup-1.1.1-py3-none-any.whl", hash = "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e"},
@@ -265,9 +503,17 @@ grpcio = [
     {file = "grpcio-1.53.0-cp39-cp39-win_amd64.whl", hash = "sha256:6beb84f83360ff29a3654f43f251ec11b809dcb5524b698d711550243debd289"},
     {file = "grpcio-1.53.0.tar.gz", hash = "sha256:a4952899b4931a6ba12951f9a141ef3e74ff8a6ec9aa2dc602afa40f63595e33"},
 ]
+idna = [
+    {file = "idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+    {file = "idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
+]
 iniconfig = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+loguru = [
+    {file = "loguru-0.7.0-py3-none-any.whl", hash = "sha256:b93aa30099fa6860d4727f1b81f8718e965bb96253fa190fab2077aaad6d15d3"},
+    {file = "loguru-0.7.0.tar.gz", hash = "sha256:1612053ced6ae84d7959dd7d5e431a0532642237ec21f7fd83ac73fe539e03e1"},
 ]
 mmh3 = [
     {file = "mmh3-3.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:16ee043b1bac040b4324b8baee39df9fdca480a560a6d74f2eef66a5009a234e"},
@@ -367,6 +613,10 @@ pandas = [
     {file = "pandas-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:4f3320bb55f34af4193020158ef8118ee0fb9aec7cc47d2084dbfdd868a0a24f"},
     {file = "pandas-2.0.0.tar.gz", hash = "sha256:cda9789e61b44463c1c4fe17ef755de77bcd13b09ba31c940d20f193d63a5dc8"},
 ]
+pinecone-client = [
+    {file = "pinecone-client-2.2.1.tar.gz", hash = "sha256:0878dcaee447c46c8d1b3d71c854689daa7e548e5009a171780907c7d4e74789"},
+    {file = "pinecone_client-2.2.1-py3-none-any.whl", hash = "sha256:6976a22aee57a9813378607506c8c36b0317dfa36a08a5397aaaeab2eef66c1b"},
+]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
@@ -402,6 +652,52 @@ pytz = [
     {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
     {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
 ]
+PyYAML = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+requests = [
+    {file = "requests-2.28.2-py3-none-any.whl", hash = "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa"},
+    {file = "requests-2.28.2.tar.gz", hash = "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -409,6 +705,14 @@ six = [
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+tqdm = [
+    {file = "tqdm-4.65.0-py3-none-any.whl", hash = "sha256:c4f53a17fe37e132815abceec022631be8ffe1b9381c2e6e30aa70edc99e9671"},
+    {file = "tqdm-4.65.0.tar.gz", hash = "sha256:1871fb68a86b8fb3b59ca4cdd3dcccbc7e6d613eeed31f4c332531977b89beb5"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.5.0-py3-none-any.whl", hash = "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"},
+    {file = "typing_extensions-4.5.0.tar.gz", hash = "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb"},
 ]
 tzdata = [
     {file = "tzdata-2023.3-py2.py3-none-any.whl", hash = "sha256:7e65763eef3120314099b6939b5546db7adce1e7d6f2e179e3df563c70511eda"},
@@ -480,4 +784,12 @@ ujson = [
     {file = "ujson-5.7.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea7423d8a2f9e160c5e011119741682414c5b8dce4ae56590a966316a07a4618"},
     {file = "ujson-5.7.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4c592eb91a5968058a561d358d0fef59099ed152cfb3e1cd14eee51a7a93879e"},
     {file = "ujson-5.7.0.tar.gz", hash = "sha256:e788e5d5dcae8f6118ac9b45d0b891a0d55f7ac480eddcb7f07263f2bcf37b23"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.15-py2.py3-none-any.whl", hash = "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"},
+    {file = "urllib3-1.26.15.tar.gz", hash = "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305"},
+]
+win32-setctime = [
+    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
+    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pinecone-client = "^2.2.1"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"
 python-dotenv = "^1.0.0"
+isort = "^5.12.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.10"
 pymilvus = "^2.2.6"
 protobuf = "^4.22.3"
 numpy = "^1.24.2"
+pinecone-client = "^2.2.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ pinecone-client = "^2.2.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"
+python-dotenv = "^1.0.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/vectordb_orm/__init__.py
+++ b/vectordb_orm/__init__.py
@@ -1,6 +1,7 @@
-from vectordb_orm.base import MilvusBase
+from vectordb_orm.base import VectorSchemaBase
 from vectordb_orm.fields import EmbeddingField, VarCharField, PrimaryKeyField
-from vectordb_orm.session import MilvusSession
+from vectordb_orm.session import VectorSession
 from vectordb_orm.indexes import FLAT, IVF_FLAT, IVF_SQ8, IVF_PQ, HNSW, BIN_FLAT, BIN_IVF_FLAT
 from vectordb_orm.similarity import ConsistencyType
-from pymilvus import Milvus
+from vectordb_orm.backends.milvus import MilvusBackend
+from vectordb_orm.backends.pinecone import PineconeBackend

--- a/vectordb_orm/__init__.py
+++ b/vectordb_orm/__init__.py
@@ -1,7 +1,14 @@
+from vectordb_orm.backends.milvus.indexes import (Milvus_BIN_FLAT,
+                                                  Milvus_BIN_IVF_FLAT,
+                                                  Milvus_FLAT, Milvus_HNSW,
+                                                  Milvus_IVF_FLAT,
+                                                  Milvus_IVF_PQ,
+                                                  Milvus_IVF_SQ8)
+from vectordb_orm.backends.milvus.milvus import MilvusBackend
+from vectordb_orm.backends.pinecone.indexes import (PineconeIndex,
+                                                    PineconeSimilarityMetric)
+from vectordb_orm.backends.pinecone.pinecone import PineconeBackend
 from vectordb_orm.base import VectorSchemaBase
-from vectordb_orm.fields import EmbeddingField, VarCharField, PrimaryKeyField
+from vectordb_orm.enums import ConsistencyType
+from vectordb_orm.fields import EmbeddingField, PrimaryKeyField, VarCharField
 from vectordb_orm.session import VectorSession
-from vectordb_orm.indexes import FLAT, IVF_FLAT, IVF_SQ8, IVF_PQ, HNSW, BIN_FLAT, BIN_IVF_FLAT
-from vectordb_orm.similarity import ConsistencyType
-from vectordb_orm.backends.milvus import MilvusBackend
-from vectordb_orm.backends.pinecone import PineconeBackend

--- a/vectordb_orm/attributes.py
+++ b/vectordb_orm/attributes.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from vectordb_orm.base import MilvusBase

--- a/vectordb_orm/attributes.py
+++ b/vectordb_orm/attributes.py
@@ -7,15 +7,15 @@ if TYPE_CHECKING:
 
 class OperationType(Enum):
     """
-    Values of the operation type should correspond to the operators used in the Milvus query language
+    Types fo comparison supported by our querying language
 
     """
-    EQUALS = '=='
-    GREATER_THAN = '>'
-    LESS_THAN = '<'
-    LESS_THAN_EQUAL = '<='
-    GREATER_THAN_EQUAL = '>='
-    NOT_EQUAL = '!='
+    EQUALS = 'EQUALS'
+    GREATER_THAN = 'GREATER_THAN'
+    LESS_THAN = 'LESS_THAN'
+    LESS_THAN_EQUAL = 'LESS_THAN_EQUAL'
+    GREATER_THAN_EQUAL = 'GREATER_THAN_EQUAL'
+    NOT_EQUAL = 'NOT_EQUAL'
 
 
 class AttributeCompare:

--- a/vectordb_orm/attributes.py
+++ b/vectordb_orm/attributes.py
@@ -45,10 +45,3 @@ class AttributeCompare:
 
     def __ge__(self, other):
         return AttributeCompare(self.base_cls, self.attr, other, OperationType.GREATER_THAN_EQUAL)
-
-    def to_expression(self):
-        value = self.value
-        if isinstance(value, str):
-            value = f"\"{self.value}\""
-
-        return f"{self.attr} {self.op.value} {value}"

--- a/vectordb_orm/backends/base.py
+++ b/vectordb_orm/backends/base.py
@@ -1,0 +1,44 @@
+from abc import ABC, abstractmethod
+from typing import Type
+from vectordb_orm.base import VectorSchemaBase
+import numpy as np
+from vectordb_orm.attributes import AttributeCompare
+from vectordb_orm.results import QueryResult
+
+class BackendBase(ABC):
+    @abstractmethod
+    def create_collection(self, schema: Type[VectorSchemaBase]):
+        pass
+
+    @abstractmethod
+    def delete_collection(self, schema: Type[VectorSchemaBase]):
+        pass
+
+    @abstractmethod
+    def insert(self, entity: VectorSchemaBase) -> int:
+        pass
+
+    @abstractmethod
+    def delete(self, entity: VectorSchemaBase):
+        pass
+
+    @abstractmethod
+    def search(
+        self,
+        cls: Type[VectorSchemaBase],
+        output_fields: list[str],
+        filters: list[AttributeCompare] | None,
+        search_embedding: np.ndarray | None,
+        search_embedding_key: str | None,
+        limit: int,
+        offset: int,
+    ) -> list[QueryResult]:
+        pass
+
+    @abstractmethod
+    def flush(self, schema: Type[VectorSchemaBase]):
+        pass
+
+    @abstractmethod
+    def load(self, schema: Type[VectorSchemaBase]):
+        pass

--- a/vectordb_orm/backends/base.py
+++ b/vectordb_orm/backends/base.py
@@ -1,10 +1,13 @@
 from abc import ABC, abstractmethod
 from typing import Type
+
+import numpy as np
+
+from vectordb_orm.attributes import AttributeCompare
 from vectordb_orm.base import VectorSchemaBase
 from vectordb_orm.fields import PrimaryKeyField
-import numpy as np
-from vectordb_orm.attributes import AttributeCompare
 from vectordb_orm.results import QueryResult
+
 
 class BackendBase(ABC):
     max_fetch_size: int

--- a/vectordb_orm/backends/milvus.py
+++ b/vectordb_orm/backends/milvus.py
@@ -1,0 +1,274 @@
+from pymilvus import Milvus, Collection
+from pymilvus.client.types import DataType
+from pymilvus.orm.schema import CollectionSchema, FieldSchema
+from vectordb_orm.backends.base import BackendBase
+import numpy as np
+from typing import get_args, get_origin
+from logging import info
+from vectordb_orm.base import VectorSchemaBase
+from typing import Type
+from pymilvus import Milvus, Collection
+from pymilvus.client.types import DataType
+from pymilvus.orm.schema import CollectionSchema, FieldSchema
+from vectordb_orm.fields import EmbeddingField, VarCharField, BaseField, PrimaryKeyField
+from vectordb_orm.indexes import FLOATING_INDEXES, BINARY_INDEXES
+from typing import Any
+from vectordb_orm.attributes import AttributeCompare
+
+from pymilvus.client.abstract import ChunkedQueryResult
+from vectordb_orm.results import QueryResult
+
+class MilvusBackend(BackendBase):
+    def __init__(self, milvus_client: Milvus):
+        self.client = milvus_client
+
+    def create_collection(self, schema: Type[VectorSchemaBase]):
+        # Additional Milvus specific validation
+        self._assert_embedding_validity(schema)
+
+        fields: list[FieldSchema] = []
+
+        for attribute_name, type_hint in schema.__annotations__.items():
+            fields.append(
+                self._field_schema_from_typehint(
+                    attribute_name,
+                    type_hint,
+                    schema._type_configuration.get(attribute_name)
+                )
+            )
+
+        print(f"Creating collection {schema.collection_name()} with schema {fields}")
+
+        field_schema = CollectionSchema(fields=fields, description=f"{schema.__name__} vectordb-generated collection")
+        collection = Collection(schema.collection_name(), field_schema)
+
+        # For all embeddings, create an associated index
+        for attribute_name, field_configuration in schema._type_configuration.items():
+            if isinstance(field_configuration, EmbeddingField):
+                index = {
+                    "index_type": field_configuration.index.index_type,
+                    "metric_type": field_configuration.index.metric_type.value,
+                    "params": field_configuration.index.get_index_parameters(),
+                }
+                print(f"Creating index {index} for field {attribute_name}")
+                collection.create_index("embedding", index)
+
+        return collection
+
+    def delete_collection(self, schema: Type[VectorSchemaBase]):
+        self.client.drop_collection(schema.collection_name())
+
+    def insert(self, entity: VectorSchemaBase) -> int:
+        entities = self._dict_representation(entity)
+        print("Entity insertion", entities)
+        mutation_result = self.client.insert(collection_name=entity.__class__.collection_name(), entities=entities)
+        return mutation_result.primary_keys[0]
+
+    def delete(self, entity: VectorSchemaBase):
+        schema = entity.__class__
+        identifier_key = schema._get_primary()
+        # Milvus only supports deleting entities with the `in` conditional; equality doesn't work
+        delete_expression = f"{identifier_key} in [{entity.id}]"
+        self.client.delete(collection_name=schema.collection_name(), expr=delete_expression)
+
+    def search(
+        self,
+        schema: Type[VectorSchemaBase],
+        output_fields: list[str],
+        filters: list[AttributeCompare] | None,
+        search_embedding: np.ndarray | None,
+        search_embedding_key: str | None,
+        limit: int,
+        offset: int,
+    ):
+        filters = " and ".join(
+            [
+                self._attribute_to_expression(f)
+                for f in filters
+            ]
+        ) if filters else None
+
+        optional_args = dict()
+        if schema.consistency_type() is not None:
+            optional_args["consistency_level"] = schema.consistency_type().value
+
+        if search_embedding_key is not None:
+            embedding_configuration : EmbeddingField = schema._type_configuration.get(search_embedding_key)
+
+            # Go through the same type conversion as the embedding field during insert time
+            _, similarity_value = self._type_to_value(
+                schema.__annotations__[search_embedding_key],
+                search_embedding,
+            )
+            query_records = [similarity_value]
+
+            search_result = self.client.search(
+                data=query_records,
+                anns_field=search_embedding_key,
+                param=embedding_configuration.index.get_inference_parameters(),
+                limit=limit,
+                offset=offset,
+                collection_name=schema.collection_name(),
+                expression=filters,
+                output_fields=output_fields,
+                **optional_args,
+            )
+        else:
+            search_result = self.client.query(
+                expr=filters,
+                offset=offset,
+                limit=limit,
+                output_fields=output_fields,
+                collection_name=schema.collection_name(),
+                **optional_args,
+            )
+        return self._result_to_objects(schema, search_result)
+
+    def flush(self, schema: Type[VectorSchemaBase]):
+        self.client.flush([schema.collection_name()])
+
+    def load(self, schema: Type[VectorSchemaBase]):
+        self.client.load_collection(schema.collection_name())
+
+    def _field_schema_from_typehint(cls, name: str, type_hint: Any, field_customization: BaseField | None = None):
+        """
+        Create a FieldSchema based on the provided type hint and field customization.
+
+        This function is called internally during the creation of a MilvusBase instance.
+
+        :param name: The name of the field.
+        :param type_hint: The type hint for the field.
+        :param field_customization: An optional customization object for the field.
+        :returns: A FieldSchema instance.
+        :raises ValueError: If an unsupported type hint is provided or the type hint configuration is incorrect.
+        """
+        if issubclass(extract_base_type(type_hint), np.ndarray):
+            if not isinstance(field_customization, EmbeddingField):
+                raise ValueError("Embedding typehints should be configured with vectordb.EmbeddingField")
+
+            type_arguments = get_args(type_hint)
+            vector_type = (
+                DataType.BINARY_VECTOR
+                if type_arguments and type_arguments[0] == np.bool_
+                else DataType.FLOAT_VECTOR
+            )
+
+            return FieldSchema(name=name, dtype=vector_type, dim=field_customization.dim)
+        elif issubclass(type_hint, str):
+            if not isinstance(field_customization, VarCharField):
+                raise ValueError("String typehints should be configured with vectordb.VarCharField")
+            return FieldSchema(name=name, dtype=DataType.VARCHAR, max_length=field_customization.max_length)
+        elif issubclass(type_hint, int):
+            # We currently only support ints as the primary key
+            is_primary = isinstance(field_customization, PrimaryKeyField)
+
+            # Mirror the python int sizing
+            return FieldSchema(name=name, dtype=DataType.INT64, is_primary=is_primary, auto_id=is_primary)
+        elif issubclass(type_hint, float):
+            # Mirror the python float sizing, equal to a double
+            return FieldSchema(name=name, dtype=DataType.DOUBLE)
+        else:
+            raise ValueError(f"{cls.__name__}: Typehint {name}:{type_hint} is not supported")
+
+    def _type_to_value(self, type_hint, value: Any | None = None):
+        """
+        Use the typehint signatures to convert into milvus DataType. Also convert the values
+        into the correct format for milvus insertion.
+
+        """
+        if issubclass(extract_base_type(type_hint), np.ndarray):
+            type_arguments = get_args(type_hint)
+            vector_type = (
+                DataType.BINARY_VECTOR
+                if type_arguments and type_arguments[0] == np.bool_
+                else DataType.FLOAT_VECTOR
+            )
+            if vector_type == DataType.BINARY_VECTOR:
+                if value is not None:
+                    packed_uint8_array = np.packbits(value)
+                    #value = packed_uint8_array.tobytes()
+                    value = bytes(packed_uint8_array.tolist())
+                return vector_type, value
+            else:
+                if value is not None:
+                    value = value.tolist()
+                return vector_type, value
+        elif issubclass(type_hint, str):
+            return DataType.VARCHAR, value
+        elif issubclass(type_hint, int):
+            return DataType.INT64, value
+        elif issubclass(type_hint, float):
+            return DataType.DOUBLE, value
+        else:
+            raise ValueError(f"Typehint {type_hint} is not supported")
+
+    def _dict_representation(self, entity: VectorSchemaBase):
+        """
+        Convert the MilvusBase object to a dictionary representation for storage.
+
+        This function is called internally during the insertion of a MilvusBase object.
+
+        :returns: A list of dictionaries containing the name, type, and values of the attributes.
+        """
+        payload = []
+
+        for attribute_name, type_hint in entity.__annotations__.items():
+            value = getattr(entity, attribute_name)
+            if value is not None:
+                db_type, value = self._type_to_value(type_hint, value)
+                payload.append({"name": attribute_name, "type": db_type, "values": [value]})
+        return payload
+
+    def _assert_embedding_validity(self, schema: Type[VectorSchemaBase]):
+        """
+        Ensure that the embedding configurations align with the typehinting
+        """
+        # For all embeddings, create an associated index
+        for attribute_name, field_configuration in schema._type_configuration.items():
+            if not isinstance(field_configuration, EmbeddingField):
+                continue
+
+            field_index = field_configuration.index
+            vector_type, _ = self._type_to_value(schema.__annotations__[attribute_name], None)
+            # Ensure that the index type is compatible with these fields
+            if vector_type == DataType.BINARY_VECTOR and not isinstance(field_index, tuple(BINARY_INDEXES)):
+                raise ValueError(f"Index type {field_index} is not compatible with binary vectors.")
+            elif vector_type == DataType.FLOAT_VECTOR and not isinstance(field_index, tuple(FLOATING_INDEXES)):
+                raise ValueError(f"Index type {field_index} is not compatible with float vectors.")
+
+    def _result_to_objects(
+        self,
+        schema: Type[VectorSchemaBase],
+        search_result: ChunkedQueryResult | list[dict[str, Any]]
+    ):
+        query_results : list[QueryResult] = []
+
+        if isinstance(search_result, ChunkedQueryResult):
+            for hit in search_result:
+                for result in hit:
+                    entity = {
+                        key: result.entity.get(key)
+                        for key in result.entity.fields
+                    }
+                    obj = schema.from_dict(entity)
+                    query_results.append(QueryResult(obj, score=result.score, distance=result.distance))
+        else:
+            for result in search_result:
+                obj = schema.from_dict(result)
+                query_results.append(QueryResult(obj))
+
+        return query_results
+
+    def _attribute_to_expression(self, attribute: AttributeCompare):
+        value = attribute.value
+        if isinstance(value, str):
+            value = f"\"{attribute.value}\""
+
+        return f"{attribute.attr} {attribute.op.value} {value}"
+
+def extract_base_type(type):
+    """
+    Given a type like `np.ndarray[np.float32]`, return the root type `np.ndarray`.
+    Also works if passed a non-generic type like `np.ndarray`.
+    """
+    return get_origin(type) or type

--- a/vectordb_orm/backends/milvus/__init__.py
+++ b/vectordb_orm/backends/milvus/__init__.py
@@ -1,0 +1,3 @@
+from vectordb_orm.backends.milvus.indexes import *
+from vectordb_orm.backends.milvus.milvus import *
+from vectordb_orm.backends.milvus.similarity import *

--- a/vectordb_orm/backends/milvus/milvus.py
+++ b/vectordb_orm/backends/milvus/milvus.py
@@ -7,7 +7,7 @@ from pymilvus.client.abstract import ChunkedQueryResult
 from pymilvus.client.types import DataType
 from pymilvus.orm.schema import CollectionSchema, FieldSchema
 
-from vectordb_orm.attributes import AttributeCompare
+from vectordb_orm.attributes import AttributeCompare, OperationType
 from vectordb_orm.backends.base import BackendBase
 from vectordb_orm.backends.milvus.indexes import (BINARY_INDEXES,
                                                   FLOATING_INDEXES)
@@ -281,7 +281,16 @@ class MilvusBackend(BackendBase):
         if isinstance(value, str):
             value = f"\"{attribute.value}\""
 
-        return f"{attribute.attr} {attribute.op.value} {value}"
+        operation_type_maps = {
+            OperationType.EQUALS: '==',
+            OperationType.GREATER_THAN: '>',
+            OperationType.LESS_THAN: '<',
+            OperationType.LESS_THAN_EQUAL: '<=',
+            OperationType.GREATER_THAN_EQUAL: '>=',
+            OperationType.NOT_EQUAL: '!='
+        }
+
+        return f"{attribute.attr} {operation_type_maps[attribute.op]} {value}"
 
 def extract_base_type(type):
     """

--- a/vectordb_orm/backends/milvus/similarity.py
+++ b/vectordb_orm/backends/milvus/similarity.py
@@ -1,8 +1,9 @@
 from enum import Enum
-from pymilvus.client.types import MetricType
-from pymilvus.orm.types import CONSISTENCY_STRONG, CONSISTENCY_BOUNDED, CONSISTENCY_EVENTUALLY, CONSISTENCY_SESSION
 
-class FloatSimilarityMetric(Enum):
+from pymilvus.client.types import MetricType
+
+
+class MilvusFloatSimilarityMetric(Enum):
     """
     Specify the metric used for floating-point search. At inference time a query vector is broadcast to the vectors in the database
     using this approach. The string values of this enums are directly used by Milvus, see here for more info: https://milvus.io/docs/metric.md
@@ -13,7 +14,7 @@ class FloatSimilarityMetric(Enum):
     # Inner Product
     IP = MetricType.IP.name
 
-class BinarySimilarityMetric(Enum):
+class MilvusBinarySimilarityMetric(Enum):
     """
     Specify the metric used for binary search. These are distance metrics.
 
@@ -21,14 +22,3 @@ class BinarySimilarityMetric(Enum):
     JACCARD = MetricType.JACCARD.name
     TANIMOTO = MetricType.TANIMOTO.name
     HAMMING = MetricType.HAMMING.name
-
-class ConsistencyType(Enum):
-    """
-    Define the strength of the consistency within the distributed DB:
-    https://milvus.io/docs/consistency.md
-
-    """
-    STRONG = CONSISTENCY_STRONG
-    BOUNDED = CONSISTENCY_BOUNDED
-    SESSION = CONSISTENCY_SESSION
-    EVENTUALLY = CONSISTENCY_EVENTUALLY

--- a/vectordb_orm/backends/pinecone.py
+++ b/vectordb_orm/backends/pinecone.py
@@ -1,42 +1,217 @@
 import pinecone
 from vectordb_orm.backends.base import BackendBase
+from typing import Type
+from vectordb_orm.base import VectorSchemaBase
+import numpy as np
+from vectordb_orm.attributes import AttributeCompare
+from vectordb_orm.fields import EmbeddingField
+from re import match as re_match
+from logging import info
+from uuid import uuid4
+from vectordb_orm.results import QueryResult
 
 class PineconeBackend(BackendBase):
-    def __init__(self, pinecone_api_key: str, pinecone_namespace: str):
-        pinecone.init(
-            api_key=pinecone_api_key,
-            environment="us-west1-gcp",
-        )
-        self.namespace = pinecone_namespace
+    max_fetch_size = 1000
 
-    def create_collection(self, collection_name: str):
+    def __init__(
+        self,
+        api_key: str,
+        environment: str
+    ):
+        pinecone.init(
+            api_key=api_key,
+            environment=environment,
+        )
+
+    def create_collection(self, schema: Type[VectorSchemaBase]):
+        collection_name = self.transform_collection_name(schema.collection_name())
+        current_indexes = pinecone.list_indexes()
+        if collection_name in current_indexes:
+            info("Collection already created...")
+            return
+
+        info("Creating collection, this could take 30s-5min...")
+
+        self._assert_valid_collection_name(collection_name)
+        self._assert_has_primary(schema)
+
         # Pinecone allows for dynamic keys on each object
         # However we need to pre-provide the keys we want to search on
+        # This does increase memory size so we can consider adding an explict index flag
+        # for the metadata fields that we want to allow search on
+        # https://docs.pinecone.io/docs/manage-indexes#selective-metadata-indexing
         metadata_config = {
-            "indexed": ["color"]
+            "indexed": [
+                key
+                for key in schema.__annotations__.keys()
+            ]
         }
 
-        pinecone.create_index(index_name=collection_name, metric="euclidean", metadata_config=metadata_config)
+        _, embedding_field = self._get_embedding_field(schema)
+
+        pinecone.create_index(
+            name=collection_name,
+            dimension=embedding_field.dim,
+            metric="euclidean",
+            metadata_config=metadata_config
+        )
         return pinecone.Index(index_name=collection_name)
 
-    def delete_collection(self, collection_name: str):
+    def clear_collection(self, schema: Type[VectorSchemaBase]):
+        collection_name = self.transform_collection_name(schema.collection_name())
+
+        current_indexes = pinecone.list_indexes()
+        if collection_name not in current_indexes:
+            return
+
+        index = pinecone.Index(index_name=collection_name)
+        delete_response = index.delete(delete_all=True)
+        if delete_response:
+            # Success should have an empty dict
+            raise ValueError(f"Failed to clear collection {collection_name}: {delete_response}")
+
+    def delete_collection(self, schema: Type[VectorSchemaBase]):
+        collection_name = self.transform_collection_name(schema.collection_name())
+    
+        # Pinecone throws a 404 if the index doesn't exist
+        current_indexes = pinecone.list_indexes()
+        if collection_name not in current_indexes:
+            return
+
         pinecone.delete_index(collection_name)
 
-    def insert(self, collection_name: str, entities: dict) -> list:
-        primary_keys = entities.pop("id")
-        vectors = entities.pop("embedding")
-        self.client.upsert(items=zip(primary_keys, vectors))
-        return primary_keys
+    def insert(self, entity: VectorSchemaBase) -> list:
+        schema = entity.__class__
+        collection_name = self.transform_collection_name(schema.collection_name())
 
-    def delete(self, collection_name: str, expr: str):
-        primary_key = int(expr.split("[")[1].split("]")[0])
-        self.client.delete(ids=[primary_key])
+        schema = entity.__class__
+        embedding_field_key, _ = self._get_embedding_field(schema)
+        primary_key = self._get_primary(schema)
+
+        id = uuid4().int & (1<<64)-1
+
+        embedding_value : np.ndarray = getattr(entity, embedding_field_key)
+        metadata_fields = {
+            key: getattr(entity, key)
+            for key in schema.__annotations__.keys()
+            if key not in {embedding_field_key, primary_key}
+        }
+
+        index = pinecone.Index(index_name=collection_name)
+        index.upsert([
+            (
+                str(id),
+                embedding_value.tolist(),
+                {
+                    **metadata_fields,
+                    primary_key: id
+                }
+            ),
+        ])
+
+        return id
+
+    def delete(self, entity: VectorSchemaBase):
+        schema = entity.__class__
+        collection_name = self.transform_collection_name(schema.collection_name())
+        index = pinecone.Index(index_name=collection_name)
+        delete_response = index.delete(ids=[str(entity.id)])
+        if delete_response:
+            # Success should have an empty dict
+            raise ValueError(f"Failed to clear collection {collection_name}: {delete_response}")
 
     def search(
         self,
-        collection_name: str,
-        query_vectors,
-        filters: dict,
-        top_k: int,
+        schema: Type[VectorSchemaBase],
+        output_fields: list[str],
+        filters: list[AttributeCompare] | None,
+        search_embedding: np.ndarray | None,
+        search_embedding_key: str | None,
+        limit: int,
+        offset: int,
     ):
-        return self.client.fetch(ids=query_vectors, max_results=search_params["top_k"])
+        # For performance reasons, do not return vector metadata when top_k>1000
+        # A ORM search query automatically returns some fields, so we need to
+        # throw an error under these conditions
+        if limit > 1000:
+            raise ValueError("Pinecone only supports retrieving element values with limit <= 1000")
+
+        if offset > 0:
+            raise ValueError("Pinecone doesn't currently support query offsets")
+
+        collection_name = self.transform_collection_name(schema.collection_name())
+        primary_key = self._get_primary(schema)
+        index = pinecone.Index(index_name=collection_name) 
+
+        # Unlike some other backends, Pinecone requires us to search with some vector as the input
+        # We therefore
+        missing_vector = search_embedding is None
+        if missing_vector:
+            info("No vector provided for Pinecone search, using a zero vector to still retrieve content...")
+            search_embedding_key, embedding_configuration = self._get_embedding_field(schema)
+            search_embedding = np.zeros((embedding_configuration.dim,))
+
+        print("raw", filters)
+        filters =  {
+            attribute.attr: {"$eq": attribute.value}
+            for attribute in filters
+        }
+        print(filters)
+        query_response = index.query(
+            filter=filters,
+            top_k=limit,
+            include_values=False,
+            include_metadata=True,
+            vector=search_embedding.tolist(),
+        )
+
+        objects = []
+        for item in query_response.to_dict()["matches"]:
+            objects.append(
+                QueryResult(
+                    result=schema.from_dict(
+                        {
+                            primary_key: int(item["id"]),
+                            **item["metadata"],
+                        }
+                    ),
+                    score=item["score"] if not missing_vector else None,
+                )
+            )
+        return objects
+
+    def flush(self, schema: Type[VectorSchemaBase]):
+        # No local caching is involved in Pinecone
+        pass
+
+    def load(self, schema: Type[VectorSchemaBase]):
+        # No local caching is involved in Pinecone
+        pass
+
+    def transform_collection_name(self, collection_name: str):
+        return collection_name.replace("_", "-")
+
+    def _assert_valid_collection_name(self, collection_name: str):
+        is_valid = all(
+            [
+                collection_name,
+                re_match(r'^[a-z0-9]+(-[a-z0-9]+)*$', collection_name),
+                collection_name[0].isalnum(),
+                collection_name[-1].isalnum()
+            ]
+        )
+
+        if not is_valid:
+            raise ValueError(f"Invalid collection name: {collection_name}; must be lowercase, alphanumeric, and hyphenated.")
+
+    def _get_embedding_field(self, schema: Type[VectorSchemaBase]):
+        embedding_fields = {
+            key: value
+            for key, value in schema._type_configuration.items()
+            if isinstance(value, EmbeddingField)
+        }
+
+        if len(embedding_fields) != 1:
+            raise ValueError(f"Pinecone only supports one embedding field per collection. {schema} has {len(embedding_fields)} defined: {list(embedding_fields.keys())}.")
+
+        return list(embedding_fields.items())[0]

--- a/vectordb_orm/backends/pinecone.py
+++ b/vectordb_orm/backends/pinecone.py
@@ -1,0 +1,42 @@
+import pinecone
+from vectordb_orm.backends.base import BackendBase
+
+class PineconeBackend(BackendBase):
+    def __init__(self, pinecone_api_key: str, pinecone_namespace: str):
+        pinecone.init(
+            api_key=pinecone_api_key,
+            environment="us-west1-gcp",
+        )
+        self.namespace = pinecone_namespace
+
+    def create_collection(self, collection_name: str):
+        # Pinecone allows for dynamic keys on each object
+        # However we need to pre-provide the keys we want to search on
+        metadata_config = {
+            "indexed": ["color"]
+        }
+
+        pinecone.create_index(index_name=collection_name, metric="euclidean", metadata_config=metadata_config)
+        return pinecone.Index(index_name=collection_name)
+
+    def delete_collection(self, collection_name: str):
+        pinecone.delete_index(collection_name)
+
+    def insert(self, collection_name: str, entities: dict) -> list:
+        primary_keys = entities.pop("id")
+        vectors = entities.pop("embedding")
+        self.client.upsert(items=zip(primary_keys, vectors))
+        return primary_keys
+
+    def delete(self, collection_name: str, expr: str):
+        primary_key = int(expr.split("[")[1].split("]")[0])
+        self.client.delete(ids=[primary_key])
+
+    def search(
+        self,
+        collection_name: str,
+        query_vectors,
+        filters: dict,
+        top_k: int,
+    ):
+        return self.client.fetch(ids=query_vectors, max_results=search_params["top_k"])

--- a/vectordb_orm/backends/pinecone/__init__.py
+++ b/vectordb_orm/backends/pinecone/__init__.py
@@ -1,0 +1,2 @@
+from vectordb_orm.backends.pinecone.indexes import *
+from vectordb_orm.backends.pinecone.pinecone import *

--- a/vectordb_orm/backends/pinecone/indexes.py
+++ b/vectordb_orm/backends/pinecone/indexes.py
@@ -1,0 +1,29 @@
+from enum import Enum
+
+from vectordb_orm.index import IndexBase
+
+
+class PineconeSimilarityMetric(Enum):
+    COSINE = "cosine"
+    EUCLIDEAN = "euclidean"
+    DOT_PRODUCT = "dotproduct"
+
+
+class PineconeIndex(IndexBase):
+    """
+    Pinecone only supports one type of index
+    """
+    def __init__(self, metric_type: PineconeSimilarityMetric):
+        self.metric_type = metric_type
+        self._assert_metric_type(metric_type)
+
+    def get_index_parameters(self):
+        return {}
+
+    def get_inference_parameters(self):
+        return {"metric_type": self.metric_type.name}
+
+    def _assert_metric_type(self, metric_type: PineconeSimilarityMetric):
+        # Only support valid combinations of metric type and index
+        if isinstance(metric_type, PineconeSimilarityMetric):
+            raise ValueError(f"Index type {self} is not supported for metric type {metric_type}")

--- a/vectordb_orm/backends/pinecone/indexes.py
+++ b/vectordb_orm/backends/pinecone/indexes.py
@@ -25,5 +25,5 @@ class PineconeIndex(IndexBase):
 
     def _assert_metric_type(self, metric_type: PineconeSimilarityMetric):
         # Only support valid combinations of metric type and index
-        if isinstance(metric_type, PineconeSimilarityMetric):
+        if not isinstance(metric_type, PineconeSimilarityMetric):
             raise ValueError(f"Index type {self} is not supported for metric type {metric_type}")

--- a/vectordb_orm/backends/pinecone/pinecone.py
+++ b/vectordb_orm/backends/pinecone/pinecone.py
@@ -23,6 +23,14 @@ class PineconeBackend(BackendBase):
         api_key: str,
         environment: str
     ):
+        # Pinecone can't accept quotes in either parameters, and these are sometimes
+        # unintentionally included in env variables
+        # We quit before initializing with a more informative error message
+        if "'" in api_key or '"' in api_key:
+            raise ValueError("Pinecone `api_key` contains single or double quotes, which isn't allowed.")
+        if "'" in environment or '"' in environment:
+            raise ValueError("Pinecone `environment` contains single or double quotes, which isn't allowed.")
+
         pinecone.init(
             api_key=api_key,
             environment=environment,

--- a/vectordb_orm/base.py
+++ b/vectordb_orm/base.py
@@ -82,21 +82,3 @@ class VectorSchemaBase(metaclass=VectorSchemaBaseMeta):
                 raise ValueError(f"Key `{attribute_name}` is not allowed on {cls.__name__}")
             setattr(obj, attribute_name, value)
         return obj
-
-    @classmethod
-    def _get_primary(cls):
-        """
-        If the class has a primary key, return it, otherwise return None
-        """
-        for attribute_name in cls.__annotations__.keys():
-            if isinstance(cls._type_configuration.get(attribute_name), PrimaryKeyField):
-                return attribute_name
-        return None
-
-    @classmethod
-    def _assert_has_primary(cls):
-        """
-        Ensure we have a primary key, this is the only field that's fully required
-        """
-        if cls._get_primary() is None:
-            raise ValueError(f"Class {cls.__name__} does not have a primary key, specify `PrimaryKeyField` on the class definition.")

--- a/vectordb_orm/base.py
+++ b/vectordb_orm/base.py
@@ -1,6 +1,7 @@
-from vectordb_orm.attributes import AttributeCompare
-from vectordb_orm.similarity import ConsistencyType
 from typing import Any
+
+from vectordb_orm.attributes import AttributeCompare
+from vectordb_orm.enums import ConsistencyType
 from vectordb_orm.fields import BaseField, PrimaryKeyField
 
 

--- a/vectordb_orm/base.py
+++ b/vectordb_orm/base.py
@@ -1,24 +1,17 @@
-from pymilvus import Milvus, Collection
-from pymilvus.client.types import DataType
-from pymilvus.orm.schema import CollectionSchema, FieldSchema
 from vectordb_orm.attributes import AttributeCompare
-from vectordb_orm.fields import EmbeddingField, VarCharField, BaseField, PrimaryKeyField
-from vectordb_orm.indexes import FLOATING_INDEXES, BINARY_INDEXES
 from vectordb_orm.similarity import ConsistencyType
 from typing import Any
-import numpy as np
-from typing import get_args, get_origin
-from logging import info
+from vectordb_orm.fields import BaseField, PrimaryKeyField
 
 
-class MilvusBaseMeta(type):
+class VectorSchemaBaseMeta(type):
     def __getattr__(cls, name):
         if name in set(cls.__annotations__.keys()):
             return AttributeCompare(cls, name)
         raise AttributeError(f"'{cls.__name__}' object has no attribute '{name}'")
 
 
-class MilvusBase(metaclass=MilvusBaseMeta):
+class VectorSchemaBase(metaclass=VectorSchemaBaseMeta):
     _type_configuration: dict[str, BaseField]
 
     def __init__(self, *values: Any, **data: Any) -> None:
@@ -74,138 +67,6 @@ class MilvusBase(metaclass=MilvusBaseMeta):
         return self.__consistency_type__
 
     @classmethod
-    def _create_collection(cls, milvus_client: Milvus):
-        """
-        Create a Milvus collection using the given Milvus client.
-
-        This function is called internally during the creation of a MilvusBase instance. It translates the typehinted
-        attributes of the class into a Milvus collection schema.
-
-        :param milvus_client: An instance of the Milvus client.
-        :returns: The created Milvus collection.
-        :raises ValueError: If the class does not have a primary key defined.
-        """
-        cls._assert_has_primary()
-        cls._assert_embedding_validity()
-
-        fields: list[FieldSchema] = []
-
-        for attribute_name, type_hint in cls.__annotations__.items():
-            fields.append(
-                cls._field_schema_from_typehint(
-                    attribute_name,
-                    type_hint,
-                    cls._type_configuration.get(attribute_name)
-                )
-            )
-
-        print(f"Creating collection {cls.collection_name()} with schema {fields}")
-
-        schema = CollectionSchema(fields=fields, description=f"{cls.__name__} vectordb-generated collection")
-        collection = Collection(cls.collection_name(), schema)
-
-        # For all embeddings, create an associated index
-        for attribute_name, field_configuration in cls._type_configuration.items():
-            if isinstance(field_configuration, EmbeddingField):
-                index = {
-                    "index_type": field_configuration.index.index_type,
-                    "metric_type": field_configuration.index.metric_type.value,
-                    "params": field_configuration.index.get_index_parameters(),
-                }
-                print(f"Creating index {index} for field {attribute_name}")
-                collection.create_index("embedding", index)
-
-        return collection
-
-    @classmethod
-    def _field_schema_from_typehint(cls, name: str, type_hint: Any, field_customization: BaseField | None = None):
-        """
-        Create a FieldSchema based on the provided type hint and field customization.
-
-        This function is called internally during the creation of a MilvusBase instance.
-
-        :param name: The name of the field.
-        :param type_hint: The type hint for the field.
-        :param field_customization: An optional customization object for the field.
-        :returns: A FieldSchema instance.
-        :raises ValueError: If an unsupported type hint is provided or the type hint configuration is incorrect.
-        """
-        if issubclass(extract_base_type(type_hint), np.ndarray):
-            if not isinstance(field_customization, EmbeddingField):
-                raise ValueError("Embedding typehints should be configured with vectordb.EmbeddingField")
-
-            type_arguments = get_args(type_hint)
-            vector_type = (
-                DataType.BINARY_VECTOR
-                if type_arguments and type_arguments[0] == np.bool_
-                else DataType.FLOAT_VECTOR
-            )
-
-            return FieldSchema(name=name, dtype=vector_type, dim=field_customization.dim)
-        elif issubclass(type_hint, str):
-            if not isinstance(field_customization, VarCharField):
-                raise ValueError("String typehints should be configured with vectordb.VarCharField")
-            return FieldSchema(name=name, dtype=DataType.VARCHAR, max_length=field_customization.max_length)
-        elif issubclass(type_hint, int):
-            # We currently only support ints as the primary key
-            is_primary = isinstance(field_customization, PrimaryKeyField)
-
-            # Mirror the python int sizing
-            return FieldSchema(name=name, dtype=DataType.INT64, is_primary=is_primary, auto_id=is_primary)
-        elif issubclass(type_hint, float):
-            # Mirror the python float sizing, equal to a double
-            return FieldSchema(name=name, dtype=DataType.DOUBLE)
-        else:
-            raise ValueError(f"{cls.__name__}: Typehint {name}:{type_hint} is not supported")
-
-    def insert(self, milvus_client: Milvus) -> int:
-        """
-        Insert the current MilvusBase object into the database using the provided Milvus client.
-
-        :param milvus_client: An instance of the Milvus client.
-        :returns: The primary key of the inserted object.
-        """
-        entities = self._dict_representation()
-        print("Entity insertion", entities)
-        mutation_result = milvus_client.insert(collection_name=self.collection_name(), entities=entities)
-        self.id = mutation_result.primary_keys[0]
-        return self.id
-
-    def delete(self, milvus_client: Milvus) -> None:
-        """
-        Delete the current MilvusBase object from the database using the provided Milvus client.
-
-        :param milvus_client: An instance of the Milvus client.
-        :raises ValueError: If the object has not been inserted into the database before deletion.
-        """
-        if not self.id:
-            raise ValueError("Cannot delete object that hasn't been inserted into the database")
-
-        identifier_key = self._get_primary()
-        # Milvus only supports deleting entities with the `in` conditional; equality doesn't work
-        delete_expression = f"{identifier_key} in [{self.id}]"
-        milvus_client.delete(collection_name=self.collection_name(), expr=delete_expression)
-
-        self.id = None
-
-    def _dict_representation(self):
-        """
-        Convert the MilvusBase object to a dictionary representation for storage.
-
-        This function is called internally during the insertion of a MilvusBase object.
-
-        :returns: A list of dictionaries containing the name, type, and values of the attributes.
-        """
-        payload = []
-
-        for attribute_name, type_hint in self.__annotations__.items():
-            value = getattr(self, attribute_name)
-            if value is not None:
-                db_type, value = type_to_value(type_hint, value)
-                payload.append({"name": attribute_name, "type": db_type, "values": [value]})
-        return payload
-
-    @classmethod
     def from_dict(cls, data: dict):
         """
         Create a MilvusBase object from a dictionary.
@@ -239,62 +100,3 @@ class MilvusBase(metaclass=MilvusBaseMeta):
         """
         if cls._get_primary() is None:
             raise ValueError(f"Class {cls.__name__} does not have a primary key, specify `PrimaryKeyField` on the class definition.")
-
-    @classmethod
-    def _assert_embedding_validity(cls):
-        """
-        Ensure that the embedding configurations align with the typehinting
-        """
-        # For all embeddings, create an associated index
-        for attribute_name, field_configuration in cls._type_configuration.items():
-            if not isinstance(field_configuration, EmbeddingField):
-                continue
-
-            field_index = field_configuration.index
-            vector_type, _ = type_to_value(cls.__annotations__[attribute_name], None)
-            # Ensure that the index type is compatible with these fields
-            if vector_type == DataType.BINARY_VECTOR and not isinstance(field_index, tuple(BINARY_INDEXES)):
-                raise ValueError(f"Index type {field_index} is not compatible with binary vectors.")
-            elif vector_type == DataType.FLOAT_VECTOR and not isinstance(field_index, tuple(FLOATING_INDEXES)):
-                raise ValueError(f"Index type {field_index} is not compatible with float vectors.")
-
-
-def extract_base_type(type):
-    """
-    Given a type like `np.ndarray[np.float32]`, return the root type `np.ndarray`.
-    Also works if passed a non-generic type like `np.ndarray`.
-    """
-    return get_origin(type) or type
-
-
-def type_to_value(type_hint, value: Any | None = None):
-    """
-    Use the typehint signatures to convert into milvus DataType. Also convert the values
-    into the correct format for milvus insertion.
-
-    """
-    if issubclass(extract_base_type(type_hint), np.ndarray):
-        type_arguments = get_args(type_hint)
-        vector_type = (
-            DataType.BINARY_VECTOR
-            if type_arguments and type_arguments[0] == np.bool_
-            else DataType.FLOAT_VECTOR
-        )
-        if vector_type == DataType.BINARY_VECTOR:
-            if value is not None:
-                packed_uint8_array = np.packbits(value)
-                #value = packed_uint8_array.tobytes()
-                value = bytes(packed_uint8_array.tolist())
-            return vector_type, value
-        else:
-            if value is not None:
-                value = value.tolist()
-            return vector_type, value
-    elif issubclass(type_hint, str):
-        return DataType.VARCHAR, value
-    elif issubclass(type_hint, int):
-        return DataType.INT64, value
-    elif issubclass(type_hint, float):
-        return DataType.DOUBLE, value
-    else:
-        raise ValueError(f"Typehint {type_hint} is not supported")

--- a/vectordb_orm/enums.py
+++ b/vectordb_orm/enums.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+from pymilvus.orm.types import (CONSISTENCY_BOUNDED, CONSISTENCY_EVENTUALLY,
+                                CONSISTENCY_SESSION, CONSISTENCY_STRONG)
+
+
+class ConsistencyType(Enum):
+    """
+    Define the strength of the consistency within the distributed DB:
+    https://milvus.io/docs/consistency.md
+
+    """
+    STRONG = CONSISTENCY_STRONG
+    BOUNDED = CONSISTENCY_BOUNDED
+    SESSION = CONSISTENCY_SESSION
+    EVENTUALLY = CONSISTENCY_EVENTUALLY

--- a/vectordb_orm/fields.py
+++ b/vectordb_orm/fields.py
@@ -1,7 +1,8 @@
 from abc import ABC
-from vectordb_orm.indexes import IndexBase, FLOATING_INDEXES, BINARY_INDEXES
-from vectordb_orm.similarity import FloatSimilarityMetric, BinarySimilarityMetric
 from typing import Any
+
+from vectordb_orm.index import IndexBase
+
 
 class BaseField(ABC):
     """
@@ -19,8 +20,8 @@ class BaseField(ABC):
 
 
 class PrimaryKeyField(BaseField):
-    def __init__(self, default: Any = None):
-        super().__init__(default=default)
+    def __init__(self):
+        super().__init__(default=None)
 
 
 class EmbeddingField(BaseField):

--- a/vectordb_orm/index.py
+++ b/vectordb_orm/index.py
@@ -1,0 +1,2 @@
+class IndexBase:
+    pass

--- a/vectordb_orm/query.py
+++ b/vectordb_orm/query.py
@@ -1,8 +1,10 @@
-from vectordb_orm.backends.base import BackendBase
-from vectordb_orm.attributes import AttributeCompare
-from vectordb_orm.fields import EmbeddingField
-from vectordb_orm.base import VectorSchemaBase
 from typing import Any
+
+from vectordb_orm.attributes import AttributeCompare
+from vectordb_orm.backends.base import BackendBase
+from vectordb_orm.base import VectorSchemaBase
+from vectordb_orm.fields import EmbeddingField
+
 
 class VectorQueryBuilder:
     """

--- a/vectordb_orm/query.py
+++ b/vectordb_orm/query.py
@@ -4,9 +4,6 @@ from vectordb_orm.fields import EmbeddingField
 from vectordb_orm.base import VectorSchemaBase
 from typing import Any
 
-# https://milvus.io/docs/search.md
-MAX_MILVUS_INT = 16384
-
 class VectorQueryBuilder:
     """
     Recursive query builder to allow for chaining of queries.
@@ -68,7 +65,9 @@ class VectorQueryBuilder:
         output_fields = self._get_output_fields()
         offset = self._offset if self._offset is not None else 0
         # Sum of limit and offset should be less than MAX_MILVUS_INT
-        limit = self._limit if self._limit is not None else (MAX_MILVUS_INT - offset)
+        #limit = self._limit if self._limit is not None else (MAX_MILVUS_INT - offset)
+        # TODO: offset is only relevant really for Milvus backends
+        limit = self._limit if self._limit is not None else (self.backend.max_fetch_size - offset)
 
         return self.backend.search(
             schema=self.cls,

--- a/vectordb_orm/results.py
+++ b/vectordb_orm/results.py
@@ -2,11 +2,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from vectordb_orm.base import MilvusBase
+    from vectordb_orm.base import VectorSchemaBase
 
 @dataclass
 class QueryResult:
-    result: "MilvusBase"
+    result: "VectorSchemaBase"
 
     # Score and distance is only returned for queries requesting vector-similarity
     score: float | None = None

--- a/vectordb_orm/results.py
+++ b/vectordb_orm/results.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from vectordb_orm.base import VectorSchemaBase
@@ -9,5 +9,5 @@ class QueryResult:
     result: "VectorSchemaBase"
 
     # Score and distance is only returned for queries requesting vector-similarity
-    score: float | None = None
-    distance: float | None = None
+    score: Optional[float] = None
+    distance: Optional[float] = None

--- a/vectordb_orm/session.py
+++ b/vectordb_orm/session.py
@@ -16,45 +16,20 @@ class VectorSession:
         return VectorQueryBuilder(self.backend, *query_objects)
 
     def create_collection(self, schema: Type[VectorSchemaBase]):
-        """
-        Create a Milvus collection using the given Milvus client.
-
-        This function is called internally during the creation of a MilvusBase instance. It translates the typehinted
-        attributes of the class into a Milvus collection schema.
-
-        :param milvus_client: An instance of the Milvus client.
-        :returns: The created Milvus collection.
-        :raises ValueError: If the class does not have a primary key defined.
-        """
-        schema._assert_has_primary()
         return self.backend.create_collection(schema)
 
-    def delete_collection(self, schema: Type[VectorSchemaBase]):
-        """
-        Delete a Milvus collection using the given Milvus client.
+    def clear_collection(self, schema: Type[VectorSchemaBase]):
+        return self.backend.clear_collection(schema)
 
-        :param milvus_client: An instance of the Milvus client.
-        """
+    def delete_collection(self, schema: Type[VectorSchemaBase]):
         return self.backend.delete_collection(schema)
 
     def insert(self, obj: VectorSchemaBase) -> int:
-        """
-        Insert the current MilvusBase object into the database using the provided Milvus client.
-
-        :param milvus_client: An instance of the Milvus client.
-        :returns: The primary key of the inserted object.
-        """
         new_id = self.backend.insert(obj)
         obj.id = new_id
         return obj
 
     def delete(self, obj: VectorSchemaBase) -> None:
-        """
-        Delete the current MilvusBase object from the database using the provided Milvus client.
-
-        :param milvus_client: An instance of the Milvus client.
-        :raises ValueError: If the object has not been inserted into the database before deletion.
-        """
         if not obj.id:
             raise ValueError("Cannot delete object that hasn't been inserted into the database")
 
@@ -62,17 +37,7 @@ class VectorSession:
         obj.id = None
 
     def flush(self, schema: Type[VectorSchemaBase]):
-        """
-        Flush the collection for the given schema.
-
-        :param milvus_client: An instance of the Milvus client.
-        """
         self.backend.flush(schema)
 
     def load(self, schema: Type[VectorSchemaBase]):
-        """
-        Load the collection for the given schema.
-
-        :param milvus_client: An instance of the Milvus client.
-        """
         self.backend.load(schema)

--- a/vectordb_orm/session.py
+++ b/vectordb_orm/session.py
@@ -1,8 +1,11 @@
+from typing import Type
+
+from pymilvus import Milvus
+
+from vectordb_orm.backends.base import BackendBase
 from vectordb_orm.base import VectorSchemaBase
 from vectordb_orm.query import VectorQueryBuilder
-from vectordb_orm.backends.base import BackendBase
-from pymilvus import Milvus
-from typing import Type
+
 
 class VectorSession:
     """

--- a/vectordb_orm/session.py
+++ b/vectordb_orm/session.py
@@ -1,10 +1,78 @@
-from vectordb_orm.base import MilvusBase
-from vectordb_orm.query import MilvusQueryBuilder
+from vectordb_orm.base import VectorSchemaBase
+from vectordb_orm.query import VectorQueryBuilder
+from vectordb_orm.backends.base import BackendBase
 from pymilvus import Milvus
+from typing import Type
 
-class MilvusSession:
-    def __init__(self, milvus_client: Milvus):
-        self.milvus_client = milvus_client
+class VectorSession:
+    """
+    Core session object used to interact with a vector database backend.
 
-    def query(self, *query_objects: MilvusBase | MilvusQueryBuilder):
-        return MilvusQueryBuilder(self.milvus_client, *query_objects)
+    """
+    def __init__(self, backend: BackendBase):
+        self.backend = backend
+
+    def query(self, *query_objects: VectorSchemaBase | VectorQueryBuilder):
+        return VectorQueryBuilder(self.backend, *query_objects)
+
+    def create_collection(self, schema: Type[VectorSchemaBase]):
+        """
+        Create a Milvus collection using the given Milvus client.
+
+        This function is called internally during the creation of a MilvusBase instance. It translates the typehinted
+        attributes of the class into a Milvus collection schema.
+
+        :param milvus_client: An instance of the Milvus client.
+        :returns: The created Milvus collection.
+        :raises ValueError: If the class does not have a primary key defined.
+        """
+        schema._assert_has_primary()
+        return self.backend.create_collection(schema)
+
+    def delete_collection(self, schema: Type[VectorSchemaBase]):
+        """
+        Delete a Milvus collection using the given Milvus client.
+
+        :param milvus_client: An instance of the Milvus client.
+        """
+        return self.backend.delete_collection(schema)
+
+    def insert(self, obj: VectorSchemaBase) -> int:
+        """
+        Insert the current MilvusBase object into the database using the provided Milvus client.
+
+        :param milvus_client: An instance of the Milvus client.
+        :returns: The primary key of the inserted object.
+        """
+        new_id = self.backend.insert(obj)
+        obj.id = new_id
+        return obj
+
+    def delete(self, obj: VectorSchemaBase) -> None:
+        """
+        Delete the current MilvusBase object from the database using the provided Milvus client.
+
+        :param milvus_client: An instance of the Milvus client.
+        :raises ValueError: If the object has not been inserted into the database before deletion.
+        """
+        if not obj.id:
+            raise ValueError("Cannot delete object that hasn't been inserted into the database")
+
+        self.backend.delete(obj)
+        obj.id = None
+
+    def flush(self, schema: Type[VectorSchemaBase]):
+        """
+        Flush the collection for the given schema.
+
+        :param milvus_client: An instance of the Milvus client.
+        """
+        self.backend.flush(schema)
+
+    def load(self, schema: Type[VectorSchemaBase]):
+        """
+        Load the collection for the given schema.
+
+        :param milvus_client: An instance of the Milvus client.
+        """
+        self.backend.load(schema)

--- a/vectordb_orm/tests/conftest.py
+++ b/vectordb_orm/tests/conftest.py
@@ -6,7 +6,7 @@ from dotenv import load_dotenv
 from pymilvus import Milvus, connections
 
 from vectordb_orm import MilvusBackend, PineconeBackend, VectorSession
-from vectordb_orm.tests.models import BinaryEmbeddingObject, MyObject
+from vectordb_orm.tests.models import MilvusBinaryEmbeddingObject, MilvusMyObject, PineconeMyObject
 
 
 @pytest.fixture()
@@ -15,14 +15,14 @@ def milvus_session():
     connections.connect("default", host="localhost", port="19530")
 
     # Wipe the previous collections
-    session.delete_collection(MyObject)
-    session.delete_collection(BinaryEmbeddingObject)
+    session.delete_collection(MilvusMyObject)
+    session.delete_collection(MilvusBinaryEmbeddingObject)
 
     # Flush
     sleep(1)
 
-    session.create_collection(MyObject)
-    session.create_collection(BinaryEmbeddingObject)
+    session.create_collection(MilvusMyObject)
+    session.create_collection(MilvusBinaryEmbeddingObject)
 
     return session
 
@@ -40,9 +40,19 @@ def pinecone_session():
     # Pinecone doesn't have the notion of binary objects like Milvus does, so we
     # only create one object. Their free tier also doesn't support more than 1
     # collection, so that's another limitation that encourages a single index here.
-    session.create_collection(MyObject)
-    session.clear_collection(MyObject)
+    session.create_collection(PineconeMyObject)
+    session.clear_collection(PineconeMyObject)
 
     return session
 
 SESSION_FIXTURE_KEYS = ["milvus_session", "pinecone_session"]
+SESSION_MODEL_PAIRS = [
+    (
+        "milvus_session",
+        MilvusMyObject,
+    ),
+    (
+        "pinecone_session",
+        PineconeMyObject,
+    ),
+]

--- a/vectordb_orm/tests/conftest.py
+++ b/vectordb_orm/tests/conftest.py
@@ -1,10 +1,12 @@
-import pytest
-from pymilvus import Milvus, connections
-from vectordb_orm import VectorSession, MilvusBackend, PineconeBackend
-from vectordb_orm.tests.models import MyObject, BinaryEmbeddingObject
-from time import sleep
 from os import getenv
+from time import sleep
+
+import pytest
 from dotenv import load_dotenv
+from pymilvus import Milvus, connections
+
+from vectordb_orm import MilvusBackend, PineconeBackend, VectorSession
+from vectordb_orm.tests.models import BinaryEmbeddingObject, MyObject
 
 
 @pytest.fixture()

--- a/vectordb_orm/tests/milvus/test_milvus.py
+++ b/vectordb_orm/tests/milvus/test_milvus.py
@@ -1,0 +1,28 @@
+from vectordb_orm.tests.models import MilvusBinaryEmbeddingObject
+import pytest
+from vectordb_orm import VectorSession
+import numpy as np
+
+# @pierce 04-21- 2023: Currently flaky
+# https://github.com/piercefreeman/vectordb-orm/pull/5
+@pytest.mark.xfail(strict=False)
+def test_binary_collection_query(session: VectorSession):
+    # Create some MyObject instances
+    obj1 = MilvusBinaryEmbeddingObject(embedding=np.array([True] * 128))
+    obj2 = MilvusBinaryEmbeddingObject(embedding=np.array([False] * 128))
+
+    # Insert the objects into Milvus
+    session.insert(obj1)
+    session.insert(obj2)
+
+    session.flush(MilvusBinaryEmbeddingObject)
+    session.load(MilvusBinaryEmbeddingObject)  
+
+    # Test our ability to recall 1:1 the input content
+    results = session.query(MilvusBinaryEmbeddingObject).order_by_similarity(MilvusBinaryEmbeddingObject.embedding, np.array([True]*128)).limit(2).all()
+    assert len(results) == 2
+    assert results[0].result.id == obj1.id
+
+    results = session.query(MilvusBinaryEmbeddingObject).order_by_similarity(BinaryEmbeddingObject.embedding, np.array([False]*128)).limit(2).all()
+    assert len(results) == 2
+    assert results[0].result.id == obj2.id

--- a/vectordb_orm/tests/models.py
+++ b/vectordb_orm/tests/models.py
@@ -1,12 +1,11 @@
 import numpy as np
 
-from vectordb_orm import (ConsistencyType, EmbeddingField, PrimaryKeyField,
-                          VarCharField, VectorSchemaBase)
-from vectordb_orm.backends.milvus.indexes import (Milvus_BIN_FLAT,
-                                                  Milvus_IVF_FLAT)
+from vectordb_orm import (ConsistencyType, EmbeddingField, Milvus_BIN_FLAT,
+                          Milvus_IVF_FLAT, PineconeIndex, PrimaryKeyField,
+                          VarCharField, VectorSchemaBase, PineconeSimilarityMetric)
 
 
-class MyObject(VectorSchemaBase):
+class MilvusMyObject(VectorSchemaBase):
     __collection_name__ = 'my_collection'
     __consistency_type__ = ConsistencyType.STRONG
 
@@ -15,9 +14,17 @@ class MyObject(VectorSchemaBase):
     embedding: np.ndarray = EmbeddingField(dim=128, index=Milvus_IVF_FLAT(cluster_units=128))
 
 
-class BinaryEmbeddingObject(VectorSchemaBase):
+class MilvusBinaryEmbeddingObject(VectorSchemaBase):
     __collection_name__ = 'binary_collection'
     __consistency_type__ = ConsistencyType.STRONG
 
     id: int = PrimaryKeyField()
     embedding: np.ndarray[np.bool_] = EmbeddingField(dim=128, index=Milvus_BIN_FLAT())
+
+
+class PineconeMyObject(VectorSchemaBase):
+    __collection_name__ = 'my_collection'
+
+    id: int = PrimaryKeyField()
+    text: str = VarCharField(max_length=128)
+    embedding: np.ndarray = EmbeddingField(dim=128, index=PineconeIndex(metric_type=PineconeSimilarityMetric.COSINE))

--- a/vectordb_orm/tests/models.py
+++ b/vectordb_orm/tests/models.py
@@ -1,6 +1,10 @@
-from vectordb_orm import VectorSchemaBase, EmbeddingField, VarCharField, PrimaryKeyField, ConsistencyType
-from vectordb_orm.indexes import IVF_FLAT, BIN_FLAT
 import numpy as np
+
+from vectordb_orm import (ConsistencyType, EmbeddingField, PrimaryKeyField,
+                          VarCharField, VectorSchemaBase)
+from vectordb_orm.backends.milvus.indexes import (Milvus_BIN_FLAT,
+                                                  Milvus_IVF_FLAT)
+
 
 class MyObject(VectorSchemaBase):
     __collection_name__ = 'my_collection'
@@ -8,7 +12,7 @@ class MyObject(VectorSchemaBase):
 
     id: int = PrimaryKeyField()
     text: str = VarCharField(max_length=128)
-    embedding: np.ndarray = EmbeddingField(dim=128, index=IVF_FLAT(cluster_units=128))
+    embedding: np.ndarray = EmbeddingField(dim=128, index=Milvus_IVF_FLAT(cluster_units=128))
 
 
 class BinaryEmbeddingObject(VectorSchemaBase):
@@ -16,4 +20,4 @@ class BinaryEmbeddingObject(VectorSchemaBase):
     __consistency_type__ = ConsistencyType.STRONG
 
     id: int = PrimaryKeyField()
-    embedding: np.ndarray[np.bool_] = EmbeddingField(dim=128, index=BIN_FLAT())
+    embedding: np.ndarray[np.bool_] = EmbeddingField(dim=128, index=Milvus_BIN_FLAT())

--- a/vectordb_orm/tests/models.py
+++ b/vectordb_orm/tests/models.py
@@ -1,8 +1,8 @@
-from vectordb_orm import MilvusBase, EmbeddingField, VarCharField, PrimaryKeyField, ConsistencyType
+from vectordb_orm import VectorSchemaBase, EmbeddingField, VarCharField, PrimaryKeyField, ConsistencyType
 from vectordb_orm.indexes import IVF_FLAT, BIN_FLAT
 import numpy as np
 
-class MyObject(MilvusBase):
+class MyObject(VectorSchemaBase):
     __collection_name__ = 'my_collection'
     __consistency_type__ = ConsistencyType.STRONG
 
@@ -11,7 +11,7 @@ class MyObject(MilvusBase):
     embedding: np.ndarray = EmbeddingField(dim=128, index=IVF_FLAT(cluster_units=128))
 
 
-class BinaryEmbeddingObject(MilvusBase):
+class BinaryEmbeddingObject(VectorSchemaBase):
     __collection_name__ = 'binary_collection'
     __consistency_type__ = ConsistencyType.STRONG
 

--- a/vectordb_orm/tests/test_base.py
+++ b/vectordb_orm/tests/test_base.py
@@ -1,11 +1,12 @@
-import pytest
-from vectordb_orm import VectorSession
-from vectordb_orm.tests.models import MyObject
 import numpy as np
-from time import sleep
-from vectordb_orm import VectorSchemaBase, EmbeddingField, PrimaryKeyField
-from vectordb_orm.indexes import IVF_FLAT
+import pytest
+
+from vectordb_orm import (EmbeddingField, PrimaryKeyField, VectorSchemaBase,
+                          VectorSession)
+from vectordb_orm.backends.milvus.indexes import Milvus_IVF_FLAT
 from vectordb_orm.tests.conftest import SESSION_FIXTURE_KEYS
+from vectordb_orm.tests.models import MyObject
+
 
 def test_create_object():
     my_object = MyObject(text='example', embedding=np.array([1.0] * 128))
@@ -65,7 +66,7 @@ def test_milvus_invalid_typesignatures(milvus_session: VectorSession):
         __collection_name__ = 'invalid_collection'
 
         id: int = PrimaryKeyField()
-        embedding: np.ndarray[np.bool_] = EmbeddingField(dim=128, index=IVF_FLAT(cluster_units=128))
+        embedding: np.ndarray[np.bool_] = EmbeddingField(dim=128, index=Milvus_IVF_FLAT(cluster_units=128))
 
     with pytest.raises(ValueError, match="not compatible with binary vectors"):
         milvus_session.create_collection(TestInvalidObject)

--- a/vectordb_orm/tests/test_base.py
+++ b/vectordb_orm/tests/test_base.py
@@ -4,57 +4,58 @@ import pytest
 from vectordb_orm import (EmbeddingField, PrimaryKeyField, VectorSchemaBase,
                           VectorSession)
 from vectordb_orm.backends.milvus.indexes import Milvus_IVF_FLAT
-from vectordb_orm.tests.conftest import SESSION_FIXTURE_KEYS
-from vectordb_orm.tests.models import MyObject
+from vectordb_orm.tests.conftest import SESSION_MODEL_PAIRS
+from typing import Type
 
 
-def test_create_object():
-    my_object = MyObject(text='example', embedding=np.array([1.0] * 128))
+@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
+def test_create_object(session: str, model: Type[VectorSchemaBase]):
+    my_object = model(text='example', embedding=np.array([1.0] * 128))
     assert my_object.text == 'example'
     assert np.array_equal(my_object.embedding, np.array([1.0] * 128))
     assert my_object.id is None
 
 
-@pytest.mark.parametrize("session", SESSION_FIXTURE_KEYS)
-def test_insert_object(session: str, request):
+@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
+def test_insert_object(session: str, model: Type[VectorSchemaBase], request):
     session : VectorSession = request.getfixturevalue(session)
 
-    my_object = MyObject(text='example', embedding=np.array([1.0] * 128))
+    my_object = model(text='example', embedding=np.array([1.0] * 128))
     session.insert(my_object)
     assert my_object.id is not None
 
-    session.flush(MyObject)
-    session.load(MyObject)
+    session.flush(model)
+    session.load(model)
 
     # Retrieve the object and ensure the values are equivalent
-    results = session.query(MyObject).filter(MyObject.id == my_object.id).all()
+    results = session.query(model).filter(model.id == my_object.id).all()
     assert len(results) == 1
 
-    result : MyObject = results[0].result
+    result : model = results[0].result
     assert result.text == my_object.text
 
 
-@pytest.mark.parametrize("session", SESSION_FIXTURE_KEYS)
-def test_delete_object(session: str, request):
+@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
+def test_delete_object(session: str, model: Type[VectorSchemaBase],request):
     session : VectorSession = request.getfixturevalue(session)
 
-    my_object = MyObject(text='example', embedding=np.array([1.0] * 128))
+    my_object = model(text='example', embedding=np.array([1.0] * 128))
     session.insert(my_object)
 
-    session.flush(MyObject)
-    session.load(MyObject)
+    session.flush(model)
+    session.load(model)
 
-    results = session.query(MyObject).filter(MyObject.text == "example").all()
+    results = session.query(model).filter(model.text == "example").all()
     assert len(results) == 1
 
     session.delete(my_object)
 
-    session.flush(MyObject)
-    session.load(MyObject)
+    session.flush(model)
+    session.load(model)
     # Allow enough time to become consistent
     #sleep(1)
 
-    results = session.query(MyObject).filter(MyObject.text == "example").all()
+    results = session.query(model).filter(model.text == "example").all()
     assert len(results) == 0
 
 

--- a/vectordb_orm/tests/test_indexes.py
+++ b/vectordb_orm/tests/test_indexes.py
@@ -1,6 +1,6 @@
 import pytest
 from pymilvus import Milvus
-from vectordb_orm import MilvusSession, EmbeddingField, PrimaryKeyField, MilvusBase
+from vectordb_orm import VectorSession, EmbeddingField, PrimaryKeyField, VectorSchemaBase
 import numpy as np
 from vectordb_orm.indexes import IndexBase, FLOATING_INDEXES, BINARY_INDEXES
 from vectordb_orm.similarity import FloatSimilarityMetric, BinarySimilarityMetric
@@ -38,12 +38,11 @@ INDEX_DEFAULTS = {
     )
 )
 def test_floating_index(
-    milvus_client: Milvus,
-    session: MilvusSession,
+    session: VectorSession,
     index_cls: IndexBase,
     metric_type: FloatSimilarityMetric,
 ):
-    class IndexSubclassObject(MilvusBase):
+    class IndexSubclassObject(VectorSchemaBase):
         __collection_name__ = 'index_collection'
 
         id: int = PrimaryKeyField()
@@ -55,19 +54,16 @@ def test_floating_index(
             )
         )
 
-    # Drop the existing collection
-    milvus_client.drop_collection(collection_name=IndexSubclassObject.collection_name())
-
-    # Create the collection
-    collection = IndexSubclassObject._create_collection(milvus_client)
+    session.delete_collection(IndexSubclassObject)
+    session.create_collection(IndexSubclassObject)
 
     # Insert an object
     my_object = IndexSubclassObject(embedding=np.array([1.0] * 128))
-    my_object.insert(milvus_client)
+    session.insert(my_object)
 
     # Flush and load the collection
-    collection.flush()
-    collection.load()
+    session.flush(IndexSubclassObject)
+    session.load(IndexSubclassObject)
 
     # Perform a query
     results = session.query(IndexSubclassObject).order_by_similarity(IndexSubclassObject.embedding, np.array([1.0] * 128)).all()
@@ -83,12 +79,11 @@ def test_floating_index(
     )
 )
 def test_binary_index(
-    milvus_client: Milvus,
-    session: MilvusSession,
+    session: VectorSession,
     index_cls: IndexBase,
     metric_type: BinarySimilarityMetric,
 ):
-    class IndexSubclassObject(MilvusBase):
+    class IndexSubclassObject(VectorSchemaBase):
         __collection_name__ = 'index_collection'
 
         id: int = PrimaryKeyField()
@@ -100,19 +95,16 @@ def test_binary_index(
             )
         )
 
-    # Drop the existing collection
-    milvus_client.drop_collection(collection_name=IndexSubclassObject.collection_name())
-
-    # Create the collection
-    collection = IndexSubclassObject._create_collection(milvus_client)
+    session.delete_collection(IndexSubclassObject)
+    session.create_collection(IndexSubclassObject)
 
     # Insert an object
     my_object = IndexSubclassObject(embedding=np.array([True] * 128))
-    my_object.insert(milvus_client)
+    session.insert(my_object)
 
     # Flush and load the collection
-    collection.flush()
-    collection.load()
+    session.flush(IndexSubclassObject)
+    session.load(IndexSubclassObject)
 
     # Perform a query
     results = session.query(IndexSubclassObject).order_by_similarity(IndexSubclassObject.embedding, np.array([True] * 128)).all()

--- a/vectordb_orm/tests/test_indexes.py
+++ b/vectordb_orm/tests/test_indexes.py
@@ -1,10 +1,15 @@
+from itertools import product
+
+import numpy as np
 import pytest
 from pymilvus import Milvus
-from vectordb_orm import VectorSession, EmbeddingField, PrimaryKeyField, VectorSchemaBase
-import numpy as np
-from vectordb_orm.indexes import IndexBase, FLOATING_INDEXES, BINARY_INDEXES
-from vectordb_orm.similarity import FloatSimilarityMetric, BinarySimilarityMetric
-from itertools import product
+
+from vectordb_orm import (EmbeddingField, PrimaryKeyField, VectorSchemaBase,
+                          VectorSession)
+from vectordb_orm.backends.milvus.indexes import (BINARY_INDEXES,
+                                                  FLOATING_INDEXES, IndexBase)
+from vectordb_orm.backends.milvus.similarity import (
+    BinarySimilarityMetric, MilvusFloatSimilarityMetric)
 
 # Different index definitions require different kwarg arguments; we centralize
 # them here for ease of accessing them during different test runs
@@ -34,13 +39,13 @@ INDEX_DEFAULTS = {
     "index_cls,metric_type",
     product(
         FLOATING_INDEXES,
-        [item for item in FloatSimilarityMetric],
+        [item for item in MilvusFloatSimilarityMetric],
     )
 )
 def test_floating_index(
     session: VectorSession,
     index_cls: IndexBase,
-    metric_type: FloatSimilarityMetric,
+    metric_type: MilvusFloatSimilarityMetric,
 ):
     class IndexSubclassObject(VectorSchemaBase):
         __collection_name__ = 'index_collection'

--- a/vectordb_orm/tests/test_query.py
+++ b/vectordb_orm/tests/test_query.py
@@ -1,14 +1,18 @@
-import pytest
-from pymilvus import Milvus, connections
-from vectordb_orm import VectorSession
-from vectordb_orm.tests.models import MyObject, BinaryEmbeddingObject
 import numpy as np
-from time import sleep
+import pytest
 
-def test_query(session: VectorSession):
+from vectordb_orm import VectorSession
+from vectordb_orm.tests.conftest import SESSION_FIXTURE_KEYS
+from vectordb_orm.tests.models import BinaryEmbeddingObject, MyObject
+
+
+@pytest.mark.parametrize("session", SESSION_FIXTURE_KEYS)
+def test_query(session: str, request):
     """
     General test of querying and query chaining
     """
+    session : VectorSession = request.getfixturevalue(session)
+
     # Create some MyObject instances
     obj1 = MyObject(text="foo", embedding=np.array([1.0] * 128))
     obj2 = MyObject(text="bar", embedding=np.array([4.0] * 128))
@@ -56,11 +60,14 @@ def test_binary_collection_query(session: VectorSession):
     assert len(results) == 2
     assert results[0].result.id == obj2.id
 
-def test_query_default_ignores_embeddings(session: VectorSession):
+@pytest.mark.parametrize("session", SESSION_FIXTURE_KEYS)
+def test_query_default_ignores_embeddings(session: str, request):
     """
     Ensure that querying on the class by default ignores embeddings that are included
     within the type definition.
     """
+    session : VectorSession = request.getfixturevalue(session)
+
     obj1 = MyObject(text="foo", embedding=np.array([1.0] * 128))
     session.insert(obj1)
 
@@ -74,11 +81,13 @@ def test_query_default_ignores_embeddings(session: VectorSession):
     result : MyObject = results[0].result
     assert result.embedding is None
 
-
-def test_query_with_fields(session: VectorSession):
+@pytest.mark.parametrize("session", SESSION_FIXTURE_KEYS)
+def test_query_with_fields(session: str, request):
     """
     Test querying with specific fields
     """
+    session : VectorSession = request.getfixturevalue(session)
+
     obj1 = MyObject(text="foo", embedding=np.array([1.0] * 128))
     session.insert(obj1)
 

--- a/vectordb_orm/tests/test_query.py
+++ b/vectordb_orm/tests/test_query.py
@@ -1,103 +1,79 @@
 import numpy as np
 import pytest
 
-from vectordb_orm import VectorSession
-from vectordb_orm.tests.conftest import SESSION_FIXTURE_KEYS
-from vectordb_orm.tests.models import BinaryEmbeddingObject, MyObject
+from vectordb_orm import VectorSession, VectorSchemaBase
+from vectordb_orm.tests.conftest import SESSION_MODEL_PAIRS
+from typing import Type
 
 
-@pytest.mark.parametrize("session", SESSION_FIXTURE_KEYS)
-def test_query(session: str, request):
+@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
+def test_query(session: str, model: Type[VectorSchemaBase], request):
     """
     General test of querying and query chaining
     """
     session : VectorSession = request.getfixturevalue(session)
 
     # Create some MyObject instances
-    obj1 = MyObject(text="foo", embedding=np.array([1.0] * 128))
-    obj2 = MyObject(text="bar", embedding=np.array([4.0] * 128))
-    obj3 = MyObject(text="baz", embedding=np.array([7.0] * 128))
+    obj1 = model(text="foo", embedding=np.array([1.0] * 128))
+    obj2 = model(text="bar", embedding=np.array([4.0] * 128))
+    obj3 = model(text="baz", embedding=np.array([7.0] * 128))
 
     # Insert the objects into Milvus
     session.insert(obj1)
     session.insert(obj2)
     session.insert(obj3)
 
-    session.flush(MyObject)
-    session.load(MyObject)
+    session.flush(model)
+    session.load(model)
 
     # Test a simple filter and similarity ranking
-    results = session.query(MyObject).filter(MyObject.text == 'bar').order_by_similarity(MyObject.embedding, np.array([1.0]*128)).limit(2).all()
+    results = session.query(model).filter(model.text == 'bar').order_by_similarity(model.embedding, np.array([1.0]*128)).limit(2).all()
     assert len(results) == 1
     assert results[0].result.id == obj2.id
 
     # Test combined filtering
-    results = session.query(MyObject).filter(MyObject.text == 'baz', MyObject.id > 1).order_by_similarity(MyObject.embedding, np.array([8.0]*128)).limit(2).all()
+    results = session.query(model).filter(model.text == 'baz', model.id > 1).order_by_similarity(model.embedding, np.array([8.0]*128)).limit(2).all()
     assert len(results) == 1
     assert results[0].result.id == obj3.id
 
-# @pierce 04-21- 2023: Currently flaky
-# https://github.com/piercefreeman/vectordb-orm/pull/5
-@pytest.mark.xfail(strict=False)
-def test_binary_collection_query(session: VectorSession):
-    # Create some MyObject instances
-    obj1 = BinaryEmbeddingObject(embedding=np.array([True] * 128))
-    obj2 = BinaryEmbeddingObject(embedding=np.array([False] * 128))
-
-    # Insert the objects into Milvus
-    session.insert(obj1)
-    session.insert(obj2)
-
-    session.flush(BinaryEmbeddingObject)
-    session.load(BinaryEmbeddingObject)  
-
-    # Test our ability to recall 1:1 the input content
-    results = session.query(BinaryEmbeddingObject).order_by_similarity(BinaryEmbeddingObject.embedding, np.array([True]*128)).limit(2).all()
-    assert len(results) == 2
-    assert results[0].result.id == obj1.id
-
-    results = session.query(BinaryEmbeddingObject).order_by_similarity(BinaryEmbeddingObject.embedding, np.array([False]*128)).limit(2).all()
-    assert len(results) == 2
-    assert results[0].result.id == obj2.id
-
-@pytest.mark.parametrize("session", SESSION_FIXTURE_KEYS)
-def test_query_default_ignores_embeddings(session: str, request):
+@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
+def test_query_default_ignores_embeddings(session: str, model: Type[VectorSchemaBase], request):
     """
     Ensure that querying on the class by default ignores embeddings that are included
     within the type definition.
     """
     session : VectorSession = request.getfixturevalue(session)
 
-    obj1 = MyObject(text="foo", embedding=np.array([1.0] * 128))
+    obj1 = model(text="foo", embedding=np.array([1.0] * 128))
     session.insert(obj1)
 
-    session.flush(MyObject)
-    session.load(MyObject)
+    session.flush(model)
+    session.load(model)
 
     # Test a simple filter and similarity ranking
-    results = session.query(MyObject).filter(MyObject.text == 'foo').limit(2).all()
+    results = session.query(model).filter(model.text == 'foo').limit(2).all()
     assert len(results) == 1
 
-    result : MyObject = results[0].result
+    result : model = results[0].result
     assert result.embedding is None
 
-@pytest.mark.parametrize("session", SESSION_FIXTURE_KEYS)
-def test_query_with_fields(session: str, request):
+@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
+def test_query_with_fields(session: str, model: str, request):
     """
     Test querying with specific fields
     """
     session : VectorSession = request.getfixturevalue(session)
 
-    obj1 = MyObject(text="foo", embedding=np.array([1.0] * 128))
+    obj1 = model(text="foo", embedding=np.array([1.0] * 128))
     session.insert(obj1)
 
-    session.flush(MyObject)
-    session.load(MyObject)
+    session.flush(model)
+    session.load(model)
 
     # We can query for regular attributes
-    results = session.query(MyObject.text).filter(MyObject.text == 'foo').all()
+    results = session.query(model.text).filter(model.text == 'foo').all()
     assert len(results) == 1
 
     # We shouldn't be able to query for embeddings
     with pytest.raises(ValueError):
-        session.query(MyObject.embedding).filter(MyObject.text == 'foo').all()
+        session.query(model.embedding).filter(model.text == 'foo').all()


### PR DESCRIPTION
Now that the ORM syntax is working with basic test coverage and support for most of Milvus' surface area, we expand support to other backends. This starts with Pinecone.

As part of this PR we embark on a relatively significant refactor to separate the Backend logic (Milvus, Pinecone, etc) from the actual VectorDB definition and querying syntax. This results in us stripping out all the backend references to a separate `vectordb_orm.backends` import space. The items in the top package are divorsed from the backend implementation specifics, which makes switching from backend to backend almost entirely transparent.

The only nuance right now between different backends is when specifying the index. Pinecone only supports an index built on their proprietary algorithm; this index exposes the given metric type that we want to query on but not any other parameter. We add a new generic `PineconeIndex` which corresponds to this type.