### PR TITLE
Fix mixing vanilla typehints with configured schema

### DIFF
--- a/vectordb_orm/base.py
+++ b/vectordb_orm/base.py
@@ -53,7 +53,12 @@ class VectorSchemaBase(metaclass=VectorSchemaBaseMeta):
         for key in cls.__annotations__.keys():
             attribute_value = getattr(cls, key)
             cls._type_configuration[key] = attribute_value if isinstance(attribute_value, BaseField) else None
-            delattr(cls, key)
+            # All attributes will result in some value because we return a AttributeCompare by default
+            # for non-configured objects. Checking that the field is actually equal to a base
+            # value allows us to only delete legitimate configuration objects. Otherwise attempting to delete
+            # the synthetic AttributeCompare object will throw an error.
+            if isinstance(attribute_value, BaseField):
+                delattr(cls, key)
 
     @classmethod
     def collection_name(self) -> str:

--- a/vectordb_orm/tests/test_base.py
+++ b/vectordb_orm/tests/test_base.py
@@ -71,3 +71,19 @@ def test_milvus_invalid_typesignatures(milvus_session: VectorSession):
 
     with pytest.raises(ValueError, match="not compatible with binary vectors"):
         milvus_session.create_collection(TestInvalidObject)
+
+
+def test_mixed_configuration_fields(milvus_session: VectorSession):
+    """
+    Confirm that schema definitions can mix typehints that have configuration values
+    and those that only have vanilla markup.
+
+    """
+    class TestMixedConfigurationObject(VectorSchemaBase):
+        __collection_name__ = 'mixed_configuration_collection'
+
+        id: int = PrimaryKeyField()
+        is_valid: bool
+        embedding: np.ndarray = EmbeddingField(dim=128, index=Milvus_IVF_FLAT(cluster_units=128))
+
+    milvus_session.create_collection(TestMixedConfigurationObject)


### PR DESCRIPTION
This example would previously crash since the base class was trying to migrate the configuration parameters over to the internal configuration cache:

    ```
        class TestMixedConfigurationObject(VectorSchemaBase):
        __collection_name__ = 'mixed_configuration_collection'

        id: int = PrimaryKeyField()
        is_valid: bool
        embedding: np.ndarray = EmbeddingField(dim=128, index=Milvus_IVF_FLAT(cluster_units=128))

    ```

This PR fixes this case and allows users to mix configured values with non-configured keys.