### PR TITLE
Add batch insert

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -385,7 +385,7 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "fb360da7cdf923249ea6c8602f9c2e8268a2362d2a97aa8964985d167a16aa2b"
+content-hash = "277f76ff10a6edb7d38ee3a94aecd1218e13005a09b456a697b2314bef0e6eab"
 
 [metadata.files]
 certifi = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ pymilvus = "^2.2.6"
 protobuf = "^4.22.3"
 numpy = "^1.24.2"
 pinecone-client = "^2.2.1"
+tqdm = "^4.65.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/vectordb_orm/backends/base.py
+++ b/vectordb_orm/backends/base.py
@@ -29,7 +29,7 @@ class BackendBase(ABC):
         pass
 
     @abstractmethod
-    def insert_batch(self, entities: list[VectorSchemaBase]) -> list[int]:
+    def insert_batch(self, entities: list[VectorSchemaBase], show_progress: bool) -> list[int]:
         pass
 
     @abstractmethod

--- a/vectordb_orm/backends/base.py
+++ b/vectordb_orm/backends/base.py
@@ -29,6 +29,10 @@ class BackendBase(ABC):
         pass
 
     @abstractmethod
+    def insert_batch(self, entities: list[VectorSchemaBase]) -> list[int]:
+        pass
+
+    @abstractmethod
     def delete(self, entity: VectorSchemaBase):
         pass
 

--- a/vectordb_orm/backends/milvus/milvus.py
+++ b/vectordb_orm/backends/milvus/milvus.py
@@ -79,7 +79,6 @@ class MilvusBackend(BackendBase):
         # `schema_to_original_index` - since we switch to a per-schema representation, keep track of a mapping
         #    from the schema to the original index in `entities`
         # `schema_to_ids` - map of schema to the resulting primary keys
-        schema_to_entities = defaultdict(list)
         schema_to_original_index = defaultdict(list)
         schema_to_class = {}
         schema_to_ids = {}
@@ -89,11 +88,11 @@ class MilvusBackend(BackendBase):
             schema_name = schema.collection_name()
 
             schema_to_original_index[schema_name].append(i)
-            schema_to_entities[schema_name].append(entity)
             schema_to_class[schema_name] = schema
 
-        for schema_name, schema_entities in schema_to_entities.items():
+        for schema_name, schema_indexes in schema_to_original_index.items():
             schema = schema_to_class[schema_name]
+            schema_entities = [entities[index] for index in schema_indexes]
 
             # The primary key should be null at this stage of things, so we ignore it
             # during the insertion

--- a/vectordb_orm/backends/milvus/milvus.py
+++ b/vectordb_orm/backends/milvus/milvus.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from logging import info
 from typing import Any, Type, get_args, get_origin
 
@@ -6,7 +7,6 @@ from pymilvus import Collection, Milvus
 from pymilvus.client.abstract import ChunkedQueryResult
 from pymilvus.client.types import DataType
 from pymilvus.orm.schema import CollectionSchema, FieldSchema
-from collections import defaultdict
 
 from vectordb_orm.attributes import AttributeCompare, OperationType
 from vectordb_orm.backends.base import BackendBase
@@ -73,7 +73,14 @@ class MilvusBackend(BackendBase):
         mutation_result = self.client.insert(collection_name=entity.__class__.collection_name(), entities=entities)
         return mutation_result.primary_keys[0]
 
-    def insert_batch(self, entities: list[VectorSchemaBase]) -> list[int]:
+    def insert_batch(
+        self,
+        entities: list[VectorSchemaBase],
+        show_progress: bool,
+    ) -> list[int]:
+        if show_progress:
+            raise ValueError("Milvus backend does not support batch insertion progress logging because it is done in one operation.")
+
         # Group by the schema type since we allow for the insertion of multiple different schema
         # `schema_to_entities` - input entities grouped by the schema name
         # `schema_to_original_index` - since we switch to a per-schema representation, keep track of a mapping

--- a/vectordb_orm/backends/pinecone/pinecone.py
+++ b/vectordb_orm/backends/pinecone/pinecone.py
@@ -126,6 +126,9 @@ class PineconeBackend(BackendBase):
 
         return id
 
+    def insert_batch(self, entities: list[VectorSchemaBase]) -> list[int]:
+        raise NotImplementedError
+
     def delete(self, entity: VectorSchemaBase):
         schema = entity.__class__
         collection_name = self.transform_collection_name(schema.collection_name())

--- a/vectordb_orm/session.py
+++ b/vectordb_orm/session.py
@@ -27,10 +27,16 @@ class VectorSession:
     def delete_collection(self, schema: Type[VectorSchemaBase]):
         return self.backend.delete_collection(schema)
 
-    def insert(self, obj: VectorSchemaBase) -> int:
+    def insert(self, obj: VectorSchemaBase) -> VectorSchemaBase:
         new_id = self.backend.insert(obj)
         obj.id = new_id
         return obj
+
+    def insert_batch(self, objs: list[VectorSchemaBase]) -> list[VectorSchemaBase]:
+        new_ids = self.backend.insert_batch(objs)
+        for new_id, obj in zip(new_ids, objs):
+            obj.id = new_id
+        return objs
 
     def delete(self, obj: VectorSchemaBase) -> None:
         if not obj.id:

--- a/vectordb_orm/session.py
+++ b/vectordb_orm/session.py
@@ -32,8 +32,8 @@ class VectorSession:
         obj.id = new_id
         return obj
 
-    def insert_batch(self, objs: list[VectorSchemaBase]) -> list[VectorSchemaBase]:
-        new_ids = self.backend.insert_batch(objs)
+    def insert_batch(self, objs: list[VectorSchemaBase], show_progress: bool = False) -> list[VectorSchemaBase]:
+        new_ids = self.backend.insert_batch(objs, show_progress=show_progress)
         for new_id, obj in zip(new_ids, objs):
             obj.id = new_id
         return objs

--- a/vectordb_orm/tests/conftest.py
+++ b/vectordb_orm/tests/conftest.py
@@ -6,7 +6,8 @@ from dotenv import load_dotenv
 from pymilvus import Milvus, connections
 
 from vectordb_orm import MilvusBackend, PineconeBackend, VectorSession
-from vectordb_orm.tests.models import MilvusBinaryEmbeddingObject, MilvusMyObject, PineconeMyObject
+from vectordb_orm.tests.models import (MilvusBinaryEmbeddingObject,
+                                       MilvusMyObject, PineconeMyObject)
 
 
 @pytest.fixture()

--- a/vectordb_orm/tests/milvus/test_indexes.py
+++ b/vectordb_orm/tests/milvus/test_indexes.py
@@ -7,7 +7,8 @@ from pymilvus import Milvus
 from vectordb_orm import (EmbeddingField, PrimaryKeyField, VectorSchemaBase,
                           VectorSession)
 from vectordb_orm.backends.milvus.indexes import (BINARY_INDEXES,
-                                                  FLOATING_INDEXES, MilvusIndexBase)
+                                                  FLOATING_INDEXES,
+                                                  MilvusIndexBase)
 from vectordb_orm.backends.milvus.similarity import (
     MilvusBinarySimilarityMetric, MilvusFloatSimilarityMetric)
 

--- a/vectordb_orm/tests/milvus/test_milvus.py
+++ b/vectordb_orm/tests/milvus/test_milvus.py
@@ -1,7 +1,9 @@
-from vectordb_orm.tests.models import MilvusBinaryEmbeddingObject
-import pytest
-from vectordb_orm import VectorSession
 import numpy as np
+import pytest
+
+from vectordb_orm import VectorSession
+from vectordb_orm.tests.models import MilvusBinaryEmbeddingObject
+
 
 # @pierce 04-21- 2023: Currently flaky
 # https://github.com/piercefreeman/vectordb-orm/pull/5

--- a/vectordb_orm/tests/models.py
+++ b/vectordb_orm/tests/models.py
@@ -1,8 +1,9 @@
 import numpy as np
 
 from vectordb_orm import (ConsistencyType, EmbeddingField, Milvus_BIN_FLAT,
-                          Milvus_IVF_FLAT, PineconeIndex, PrimaryKeyField,
-                          VarCharField, VectorSchemaBase, PineconeSimilarityMetric)
+                          Milvus_IVF_FLAT, PineconeIndex,
+                          PineconeSimilarityMetric, PrimaryKeyField,
+                          VarCharField, VectorSchemaBase)
 
 
 class MilvusMyObject(VectorSchemaBase):

--- a/vectordb_orm/tests/test_base.py
+++ b/vectordb_orm/tests/test_base.py
@@ -34,6 +34,36 @@ def test_insert_object(session: str, model: Type[VectorSchemaBase], request):
     result : model = results[0].result
     assert result.text == my_object.text
 
+@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
+def test_insert_batch(session: str, model: Type[VectorSchemaBase], request):
+    session : VectorSession = request.getfixturevalue(session)
+
+    obj1 = model(text='example1', embedding=np.array([1.0] * 128))
+    obj2 = model(text='example2', embedding=np.array([2.0] * 128))
+    obj3 = model(text='example3', embedding=np.array([3.0] * 128))
+
+    session.insert_batch([obj1, obj2, obj3])
+
+    for obj in [obj1, obj2, obj3]:
+        assert obj.id is not None
+
+
+@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
+def test_insert_batch_with_nulls(session: str, model: Type[VectorSchemaBase], request):
+    """
+    Test bulk insertion where some of the objects have null values in them
+    """
+    session : VectorSession = request.getfixturevalue(session)
+
+    obj1 = model(text='example1', embedding=np.array([1.0] * 128))
+    obj2 = model(text=None, embedding=np.array([2.0] * 128))
+    obj3 = model(text='example3', embedding=np.array([3.0] * 128))
+
+    session.insert_batch([obj1, obj2, obj3])
+
+    for obj in [obj1, obj2, obj3]:
+        assert obj.id is not None
+
 
 @pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
 def test_delete_object(session: str, model: Type[VectorSchemaBase],request):

--- a/vectordb_orm/tests/test_base.py
+++ b/vectordb_orm/tests/test_base.py
@@ -47,24 +47,6 @@ def test_insert_batch(session: str, model: Type[VectorSchemaBase], request):
     for obj in [obj1, obj2, obj3]:
         assert obj.id is not None
 
-
-@pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
-def test_insert_batch_with_nulls(session: str, model: Type[VectorSchemaBase], request):
-    """
-    Test bulk insertion where some of the objects have null values in them
-    """
-    session : VectorSession = request.getfixturevalue(session)
-
-    obj1 = model(text='example1', embedding=np.array([1.0] * 128))
-    obj2 = model(text=None, embedding=np.array([2.0] * 128))
-    obj3 = model(text='example3', embedding=np.array([3.0] * 128))
-
-    session.insert_batch([obj1, obj2, obj3])
-
-    for obj in [obj1, obj2, obj3]:
-        assert obj.id is not None
-
-
 @pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)
 def test_delete_object(session: str, model: Type[VectorSchemaBase],request):
     session : VectorSession = request.getfixturevalue(session)

--- a/vectordb_orm/tests/test_base.py
+++ b/vectordb_orm/tests/test_base.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 import numpy as np
 import pytest
 
@@ -5,7 +7,6 @@ from vectordb_orm import (EmbeddingField, PrimaryKeyField, VectorSchemaBase,
                           VectorSession)
 from vectordb_orm.backends.milvus.indexes import Milvus_IVF_FLAT
 from vectordb_orm.tests.conftest import SESSION_MODEL_PAIRS
-from typing import Type
 
 
 @pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)

--- a/vectordb_orm/tests/test_query.py
+++ b/vectordb_orm/tests/test_query.py
@@ -1,9 +1,10 @@
+from typing import Type
+
 import numpy as np
 import pytest
 
-from vectordb_orm import VectorSession, VectorSchemaBase
+from vectordb_orm import VectorSchemaBase, VectorSession
 from vectordb_orm.tests.conftest import SESSION_MODEL_PAIRS
-from typing import Type
 
 
 @pytest.mark.parametrize("session,model", SESSION_MODEL_PAIRS)


### PR DESCRIPTION
Implement https://github.com/piercefreeman/vectordb-orm/issues/7: batch object insert.

For particular backends we can make some optimizations to the batch case, versus ad-hoc inserts. Where supported we also allow users to display a progress bar to show the current status of upserts. This status update is particularly useful on remote backends like Pinecone that might have higher latency to send content over the wire.

We can likely generalize the single insertion logic to be a batch insert of size 1 in the future. For this PR we keep the implementations separate.

```
session.insert_batch([obj1, obj2, obj3, ...])
```